### PR TITLE
ignore md monthly check

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -254,7 +254,7 @@ sub check_mdstat {
 		# linux-2.6.33/drivers/md/md.c, status_resync
 		# [==>..................]  resync = 13.0% (95900032/732515712) finish=175.4min speed=60459K/sec
 		# [=>...................]  check =  8.8% (34390144/390443648) finish=194.2min speed=30550K/sec
-		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|check|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
+		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
 			$resync_status = "$action:$perc $speed ETA: $eta";
 			next;
 		}


### PR DESCRIPTION
Don't generate a warning on the default monthly mdadm recheck
