### PR TITLE
mdadm raid0 can't have missing devices

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -231,6 +231,10 @@ sub check_mdstat {
 			next;
 		}
 
+		# raid0 is just there or its not. raid0 can't degrade.
+		$md_status = "OK" if $md_pers eq "raid0";
+
+
 		# linux-2.6.33/drivers/md/dm-raid1.c, device_status_char
 		# A => Alive - No failures
 		# D => Dead - A write failure occurred leaving mirror out-of-sync


### PR DESCRIPTION
raid0 devices in /proc/mdstat don't have the [UU] for devices.
