### PR TITLE
areca fixes, implementing issue #6

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -1394,7 +1394,8 @@ sub check_areca {
 	my @status;
 	open(my $fh, '-|', @CMD, 'rsf', 'info') or return;
 	while (<$fh>) {
-		next unless (my($s) = /^\s\d\s+Raid\sSet\s#\s\d+\s+\d+\s\d+.\d+\w+\s+\d+.\d+\w+\s+\d+.\d+\w+\s+(\w+)\s+/);
+		next unless (my($s) = /^\s*\d+\s+(.*)\s+\d+\s+\S+\s+\S+\s+\S+\s+(\S+)\s*$/);
+		$s=$2;
 
 		if ($s =~ /[Rr]e[Bb]uild/) {
 			$status = $ERRORS{WARNING} unless $status;


### PR DESCRIPTION
Hi.

Attached is:
- implementation of issue #6
- a first part of a fix to the areca controller (see the commit log for details)
- sorry for my crappy perl style ;)
- the areca check still fails for me, at least partially (namely the disk list)

outputs:

```
 # /opt/areca/cli64 disk info  # Ch# ModelName                       Capacity  Usage
===============================================================================
  1  1  WDC WD3200YS-01PGB0              320.1GB  data            
  2  2  WDC WD3200YS-01PGB0              320.1GB  data            
  3  3  WDC WD3200YS-01PGB0              320.1GB  data            
  4  4  WDC WD3200YS-01PGB0              320.1GB  data            
  5  5  WDC WD3200YS-01PGB0              320.1GB  data            
  6  6  WDC WD3200YS-01PGB0              320.1GB  data            
  7  7  WDC WD3200YS-01PGB0              320.1GB  data            
  8  8  WDC WD3200YS-01PGB0              320.1GB  data            
  9  9  WDC WD3200YS-01PGB0              320.1GB  data            
 10 10  WDC WD3200YS-01PGB0              320.1GB  data            
 11 11  WDC WD3200YS-01PGB0              320.1GB  data            
 12 12  WDC WD3200YS-01PGB0              320.1GB  data            
 13 13  WDC WD3200YS-01PGB0              320.1GB  data            
 14 14  WDC WD3200YS-01PGB0              320.1GB  data            
 15 15  WDC WD3200YS-01PGB0              320.1GB  data            
 16 16  WDC WD3200YS-01PGB0              320.1GB  HotSpare[Global]
===============================================================================
GuiErrMsg<0x00>: Success.
```

with my patches from this pull request:

```
# check_raid 
OK: areca:[Array Status: Normal, (Disk )]
```

I do not really understand what you with the SLOT patterns and that stuff around.
But to match the above lines,
/^\s_\d+\s+\d+\s+._\s+\S+\s+\S+\s*$/
would be a start IMHO.
