### PR TITLE
Fix for warning alert while checking array

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -507,7 +507,7 @@ sub parse {
 		# linux-2.6.33/drivers/md/md.c, status_resync
 		# [==>..................]  resync = 13.0% (95900032/732515712) finish=175.4min speed=60459K/sec
 		# [=>...................]  check =  8.8% (34390144/390443648) finish=194.2min speed=30550K/sec
-		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|check|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
+		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
 			$md{resync_status} = "$action:$perc $speed ETA: $eta";
 			next;
 		}


### PR DESCRIPTION
Weekly/monthly checks on large arrays take quite a long time leaving it in a warning status while it executes.

This change prevents a checking array from returning a warning.

If there is an inconsistency detected while the check is running you will receive a "resync=delayed" and warning return code, otherwise the check will return OK.
