### PR TITLE
Fix for varios cciss_vol_status related issues

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -2605,8 +2605,10 @@ sub check {
 package hpacucli;
 use base 'plugin';
 
-# register
-push(@utils::plugins, __PACKAGE__);
+# register if cciss_vol_status is not available
+if (! -x utils::which('cciss_vol_status')) {
+	push(@utils::plugins, __PACKAGE__);
+}
 
 sub program_names {
 	__PACKAGE__;


### PR DESCRIPTION
- print smartctl output
- actually look at the smartctl status
- Fix issue #19 - /proc/driver/cciss is the appropriate path,
  not /proc/scsi/cciss
