### PR TITLE
mpt: fix plugin when disk model contains a space

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -1153,8 +1153,9 @@ sub parse {
 		# mpt-status.c __print_physdisk_classic
 		# ioc0 phy 0 scsi_id 0 IBM-ESXS PYH146C3-ETS10FN RXQN, 136 GB, state ONLINE, flags NONE
 		# ioc0 phy 0 scsi_id 1 ATA      ST3808110AS      J   , 74 GB, state ONLINE, flags NONE
+		# ioc0 phy 0 scsi_id 1 ATA      Hitachi HUA72101 AJ0A, 931 GB, state ONLINE, flags NONE
 		elsif (my($pioc, $num, $phy_id, $vendor, $prod_id, $rev, $size, $state, $flags) =
-			/^ioc(\d+)\s+ phy\s(\d+)\s scsi_id\s(\d+)\s (\S+)\s+(\S+)\s+(\S+)\s*,\s (\d+)\sGB,\s state\s(\S+),\s flags\s(.+)/x) {
+			/^ioc(\d+)\s+ phy\s(\d+)\s scsi_id\s(\d+)\s (\S+)\s+(\S+).+(\S+)\s*,\s (\d+)\sGB,\s state\s(\S+),\s flags\s(.+)/x) {
 			$pd{$num} = {
 				ioc => int($pioc),
 				num => int($num),


### PR DESCRIPTION
Hi Elan,

We installed the latest version of check_raid on our servers today and found that the mpt plugin no longer worked correctly for us. The simple patch here fixes it for us. Please consider merging this commit.

Thanks,
Chris
