### PR TITLE
Feature: Decrease CRTITCAL ERRORS to WARNING

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -3008,7 +3008,7 @@ use strict;
 use warnings;
 use Getopt::Long;
 
-my ($opt_V, $opt_d, $opt_h, $opt_W, $opt_S, $opt_p, $opt_l);
+my ($opt_V, $opt_d, $opt_h, $opt_W, $opt_C, $opt_S, $opt_p, $opt_l);
 my (%ERRORS) = (OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3);
 my ($VERSION) = "3.0.1";
 my ($message, $status);
@@ -3038,6 +3038,8 @@ sub print_usage() {
 	"    Setup sudo rules",
 	" -W, --warnonly",
 	"    Treat CRITICAL errors as WARNING",
+	" -C, --nocritical",
+	"    Decrease CRITICAL to WARNING",
 	" -p, --plugin <name(s)>",
 	"    Force the use of selected plugins, comma separated",
 	" -l, --list-plugins",
@@ -3143,6 +3145,7 @@ GetOptions(
 	'h' => \$opt_h, 'help' => \$opt_h,
 	'S' => \$opt_S, 'sudoers' => \$opt_S,
 	'W' => \$opt_W, 'warnonly' => \$opt_W,
+	'C' => \$opt_C, 'nocritical' => \$opt_C,
 	'p=s' => \$opt_p, 'plugin=s' => \$opt_p,
 	'l' => \$opt_l, 'list-plugins' => \$opt_l,
 ) or exit($ERRORS{UNKNOWN});
@@ -3199,6 +3202,14 @@ foreach my $pn (@plugins) {
 	$status = $plugin->status if $plugin->status > $status;
 	$message .= '; ' if $message;
 	$message .= "$pn:[".$plugin->message."]";
+}
+
+# If --nocritical was set and the final statuslevel
+# is CRITICAL, the statuslevel will be set to WARNING
+if ($opt_C) {
+	if ($status == $ERRORS{CRITICAL}) {
+		$status = $ERRORS{WARNING};
+	}
 }
 
 if ($message) {


### PR DESCRIPTION
Hi Elan

I don't know if I didn't understand the --warnonly option correctly.

There are two diffrent explanations for this Option
In your readme:

```
-W  --warnonly          Don't send CRITICAL status
```

and in the code.

```
Treat CRITICAL errors as WARNING
```

What I experienced with the -W option, is that CRITICAL is changed to UNKNOWN.
According to your Readme this is may be correct.

From the explanation of the --help option, I thought a CRITIAL ERROR will be decreased to WARNING.

Without any option:

```
# perl check_raid.pl
CRITICAL: mdstat:[md1(927.52 GiB raid1):UU, md0(203.81 MiB raid1):F:sda1:_U]
```

And with --warnonly option

```
# perl check_raid.pl -W
UNKNOWN: mdstat:[md1(927.52 GiB raid1):UU, md0(203.81 MiB raid1):F:sda1:_U]
```

My pullrequest adds the --nocritical option.
The ERROR level for a CRITICAL ERROR will be decreased to WARNING.

Without any option:

```
# perl check_raid.pl
CRITICAL: mdstat:[md1(927.52 GiB raid1):UU, md0(203.81 MiB raid1):F:sda1:_U]
```

And with  option

```
# perl check_raid.pl -C
WARNING: mdstat:[md1(927.52 GiB raid1):UU, md0(203.81 MiB raid1):F:sda1:_U]
```
