### PR TITLE
changed order of else in mdadm to fix resync information.

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -615,7 +615,11 @@ sub check {
 		# same for linear, no $md_status available
 		if ($md{personality} =~ /linear|raid0/) {
 			$s .= "OK";
-
+			
+		} elsif ($md{resync_status}) {
+			$this->warning;
+			$s .= "$md{status} ($md{resync_status})";
+			
 		} elsif ($md{status} =~ /_/) {
 			$this->critical;
 			$s .= "F:". join(",", @{$md{failed_disks}}) .":$md{status}";
@@ -624,10 +628,6 @@ sub check {
 			# FIXME: this is same as above?
 			$this->warning;
 			$s .= "hot-spare failure:". join(",", @{$md{failed_disks}}) .":$md{status}";
-
-		} elsif ($md{resync_status}) {
-			$this->warning;
-			$s .= "$md{status} ($md{resync_status})";
 
 		} else {
 			$s .= "$md{status}";


### PR DESCRIPTION
Hi Elan

As mentioned from in Issue #24, the mdadm check stays on failed disk, even if it's resyncing or resync delayed.

I changed the order in the if statement which fixes this issue.

Example how it look with the changed order:

When one md device is OK, and the other one is rebuilding:

```
# perl check_raid.pl
WARNING: mdstat:[md1(927.52 GiB raid1):UU, md0(203.81 MiB raid1):_U (recovery:0.2% 11K/sec ETA: 286.2min)]
```

```
# cat /proc/mdstat 
Personalities : [raid1] 
md1 : active raid1 sda2[0] sdb2[1]
      972574976 blocks [2/2] [UU]

md0 : active raid1 sda1[2] sdb1[1]
      208704 blocks [2/1] [_U]
      [>....................]  recovery =  0.4% (1024/208704) finish=276.9min speed=12K/sec

unused devices: <none>
```

When one md device is resyncing and the other is set faulty or removed:

```
# perl check_raid_new.pl
CRITICAL: mdstat:[md1(927.52 GiB raid1):F::_U, md0(203.81 MiB raid1):_U (recovery:3.4% 12K/sec ETA: 268.3min)]
```

```
# cat /proc/mdstat 
Personalities : [raid1] 
md1 : active raid1 sdb2[1]
      972574976 blocks [2/1] [_U]

md0 : active raid1 sda1[2] sdb1[1]
      208704 blocks [2/1] [_U]
      [>....................]  recovery =  3.6% (7680/208704) finish=259.6min speed=12K/sec

unused devices: <none>
```

When both md devices are resyincing (or planing to resync)

```
# perl check_raid_new.pl
WARNING: mdstat:[md1(927.52 GiB raid1):_U (resync=DELAYED), md0(203.81 MiB raid1):_U (recovery:3.9% 12K/sec ETA: 267.3min)]
```

```
# cat /proc/mdstat 
Personalities : [raid1] 
md1 : active raid1 sda2[2] sdb2[1]
      972574976 blocks [2/1] [_U]
        resync=DELAYED

md0 : active raid1 sda1[2] sdb1[1]
      208704 blocks [2/1] [_U]
      [>....................]  recovery =  3.9% (8448/208704) finish=267.0min speed=12K/sec

unused devices: <none>
```
