### PR TITLE
3ware: VERIFYING is a normal operation

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -1660,10 +1660,10 @@ sub check {
 		while (<$fh>) {
 			next unless (my($u, $s, $p, $p2) = /^(u\d+)\s+\S+\s+(\S+)\s+(\S+)\s+(\S+)/);
 
-			if ($s eq 'OK') {
+			if ($s =~ m{ \A OK|VERIFYING \z }xms) {
 				push(@cstatus, "$u:$s");
 
-			} elsif ($s =~ 'INITIALIZING|VERIFYING') {
+			} elsif ($s =~ 'INITIALIZING') {
 				$this->warning;
 				push(@cstatus, "$u:$s $p2");
 


### PR DESCRIPTION
The code of check_raid contains an obvious bug in trying
to do a string-compare on a regexp. In

```
    /usr/lib/nagios/plugins/check_raid
    check_tw_cli(), line 738:

    } elsif ($s eq 'INITIALIZING|VERIFYING') {
```

The effect is that both status (INITIALIZING and VERIFYING)
will not be recognized and be reported as UNKNOWN. Also
the VERIFYING state will happen as part of a normal operation.
That is especially true if the auto-verification feature
is enabled. To avoid noise this state should be classified
as OK.

Patch was submitted by Harald Wilhelmi harald.wilhelmi@tngtech.com
in Debian Bug #689297 (http://bugs.debian.org/689297)
