### PR TITLE
megacli: Fixed handling of multiple Virtual Drive without name

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -858,9 +858,18 @@ sub check {
 
 	$fh = $this->cmd('ldinfo');
 	while (<$fh>) {
-		if (my($s) = /Name\s*:\s*(\S+)/) {
+		if (/Virtual Drive\s*:\s*(\d+)\s*\(Target Id:\s*(\d+)\)/i) {
+			my $drive_id=$1;
+			my $target_id=$2;
 			push(@vols, { %cur_vol }) if %cur_vol;
-			%cur_vol = ( name => $s, state => undef );
+			# Default to DriveID:TragetID in case no Name is given ...
+			%cur_vol = ( name => "$drive_id:$target_id", state => undef );
+			next;
+		} 
+		if (/Name\s*:\s*(\S+)/) {
+			my $name=$1;
+			# Add a symbolic name, if given
+			$cur_vol{"name"}=$name;
 			next;
 		}
 		if (my($s) = /State\s*:\s*(\S+)/) {


### PR DESCRIPTION
Example configuration where check_raid.pl did not work: 

```
[root@SERVER:~]# MegaCli64 -LdInfo -Lall -aALL -NoLog


Adapter 0 -- Virtual Drive Information:
Virtual Drive: 0 (Target Id: 0)
Name                :
RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
Size                : 135.972 GB
State               : Optimal
Stripe Size         : 128 KB
Number Of Drives    : 2
Span Depth          : 1
Default Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Current Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Access Policy       : Read/Write
Disk Cache Policy   : Disabled
Encryption Type     : None


Virtual Drive: 1 (Target Id: 1)
Name                :
RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
Size                : 135.972 GB
State               : Optimal
Stripe Size         : 128 KB
Number Of Drives    : 2
Span Depth          : 1
Default Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Current Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Access Policy       : Read/Write
Disk Cache Policy   : Disabled
Encryption Type     : None


Virtual Drive: 2 (Target Id: 2)
Name                :
RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
Size                : 135.972 GB
State               : Optimal
Stripe Size         : 128 KB
Number Of Drives    : 2
Span Depth          : 1
Default Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Current Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
Access Policy       : Read/Write
Disk Cache Policy   : Disabled
Encryption Type     : None
```

```
[root@SERVER:~]# /usr/local/nagios/libexec/check_raid.pl.ORG -p megacli
OK: megacli:[Volumes(1): NoName:Optimal; Devices(6): 11,10,09,08,12,13=Online]
```
