### PR TITLE
ignore some unsed values of Physical Device information of arcconf

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -2215,6 +2215,12 @@ sub parse_config {
 					}
 					# here's actually more to parse
 				}
+			} elsif (/Expander ID\s+:/) {
+				# not parsed yet
+			} elsif (/Enclosure Logical Identifier\s+:/) {
+				# not parsed yet
+			} elsif (/Expander SAS Address\s+:/) {
+				# not parsed yet
 			} else {
 				warn "Unparsed Physical Device data: [$_]\n";
 			}


### PR DESCRIPTION
on a Adaptec Series 7 controller with arcconf Version 1.4 (B20853) I get these unparsed values, which I think are not needed at the moment:

 [         Expander ID                        : 0]
 [         Enclosure Logical Identifier       : DEADBEEFDEADBEEF]
 [         Expander SAS Address               : DEADBEEFDEADBEEF]
