### PR TITLE
Batteries check (megacli): test data, return CRITICAL when battery state is "Non Operational"

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -969,7 +969,7 @@ sub check {
 
 	my (%bstatus, @bpdata, @blongout);
 	foreach my $bat (@bats) {
-		if ($bat->{state} !~ /Operational|Optimal/) {
+		if ($bat->{state} !~ /^Operational|Optimal$/) {
 			$this->critical;
 		}
 		if ($bat->{missing} ne 'No') {

--- a/t/check_megacli.t
+++ b/t/check_megacli.t
@@ -6,7 +6,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 30;
+use Test::More tests => 63;
 use test;
 
 my @tests = (
@@ -16,6 +16,9 @@ my @tests = (
 		ldinfo => 'megacli.ldinfo.1',
 		battery => 'empty',
 		message => 'Volumes(2): OS:Optimal,DATA:Optimal; Devices(12): 14,16=Hotspare 04,05,06,07,08,09,10,11,12,13=Online',
+		perfdata => '',
+		longoutput => '',
+		
 	},
 	{
 		status => OK,
@@ -23,6 +26,8 @@ my @tests = (
 		ldinfo => 'megacli.ldinfo.2',
 		battery => 'empty',
 		message => 'Volumes(1): DISK0.0:Optimal; Devices(11): 16=Hotspare 11,12,13,14,15,17=Online 18,19,20,21=Unconfigured(good)',
+		perfdata => '',
+		longoutput => '',
 	},
 	{
 		status => OK,
@@ -30,6 +35,8 @@ my @tests = (
 		ldinfo => 'issue41/ldinfo',
 		battery => 'empty',
 		message => 'Volumes(3): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal; Devices(6): 11,10,09,08,12,13=Online',
+		perfdata => '',
+		longoutput => '',
 	},
 	{
 		status => CRITICAL,
@@ -37,6 +44,8 @@ my @tests = (
 		ldinfo => 'empty',
 		battery => 'empty',
 		message => 'Volumes(0): ; Devices(11): 16=Hotspare 11,12,13,14,15,17=Online 18,19,20,21=Unconfigured(good)',
+		perfdata => '',
+		longoutput => '',
 	},
 	{
 		status => CRITICAL,
@@ -44,6 +53,35 @@ my @tests = (
 		ldinfo => 'issue39/batteries.ldinfo',,
 		battery => 'issue39/batteries.bbustatus',
 		message => 'Volumes(1): DISK0.0:Optimal; Devices(12): 14,16=Hotspare 04,05,06,07,08,09,10,11,12,13=Online; Batteries(1): 0=Faulty',
+		perfdata => 'Battery0=30;4026',
+		longoutput => "Battery0:\n - State: Faulty\n - Missing: No\n - Replacement required: Yes\n - Temperature: OK (30 C)\n - Voltage: OK (4026 mV)",
+	},
+    {
+		status => OK,
+		pdlist => 'issue39/batteries.pdlist.1',
+		ldinfo => 'issue39/batteries.ldinfo.1',,
+		battery => 'issue39/batteries.bbustatus.1',
+		message => 'Volumes(1): DISK0.0:Optimal; Devices(2): 08,07=Online; Batteries(1): 0=Operational',
+		perfdata => 'Battery0=18;3923',
+		longoutput => "Battery0:\n - State: Operational\n - Missing: No\n - Replacement required: No\n - About to fail: No\n - Temperature: OK (18 C)\n - Voltage: OK (3923 mV)",
+	},
+    {
+		status => CRITICAL,
+		pdlist => 'issue39/batteries.pdlist.2',
+		ldinfo => 'issue39/batteries.ldinfo.2',,
+		battery => 'issue39/batteries.bbustatus.2',
+		message => 'Volumes(1): DISK0.0:Optimal; Devices(2): 04,05=Online; Batteries(1): 0=Operational',
+		perfdata => 'Battery0=26;4053',
+		longoutput => "Battery0:\n - State: Operational\n - Missing: No\n - Replacement required: Yes\n - About to fail: No\n - Temperature: OK (26 C)\n - Voltage: OK (4053 mV)",
+	},
+	{
+		status => CRITICAL,
+		pdlist => 'issue39/batteries.pdlist.3',
+		ldinfo => 'issue39/batteries.ldinfo.3',,
+		battery => 'issue39/batteries.bbustatus.3',
+		message => 'Volumes(1): DISK0.0:Optimal; Devices(2): 04,05=Online; Batteries(1): 0=Non Operational',
+		perfdata => 'Battery0=22;4090',
+		longoutput => "Battery0:\n - State: Non Operational\n - Missing: No\n - Replacement required: No\n - About to fail: No\n - Temperature: OK (22 C)\n - Voltage: OK (4090 mV)",
 	},
 	{
 		status => OK,
@@ -51,6 +89,8 @@ my @tests = (
 		ldinfo => 'issue45/MegaCli64-ldinfo.out',
 		battery => 'issue45/MegaCli64-adpbbucmd.out',
 		message => 'Volumes(7): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal,DISK3.3:Optimal,DISK4.4:Optimal,DISK5.5:Optimal,DISK6.6:Optimal; Devices(8): 11,12,13,14,10,15,09,08=Online; Batteries(1): 0=Optimal',
+		perfdata => 'Battery0=34;4073',
+		longoutput => "Battery0:\n - State: Optimal\n - Missing: No\n - Replacement required: No\n - About to fail: No\n - Temperature: OK (34 C)\n - Voltage: OK (4073 mV)",
 	},
 );
 
@@ -61,6 +101,8 @@ my @tests = (
 		ldinfo => '', # MISSING
 		battery => 'issue49/battery',
 		message => 'Volumes(7): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal,DISK3.3:Optimal,DISK4.4:Optimal,DISK5.5:Optimal,DISK6.6:Optimal; Devices(1): 10 ()=; Batteries(1): 0=Faulty',
+		perfdata => '',
+		longoutput => '',
 	},
 
 =cut
@@ -84,4 +126,14 @@ foreach my $test (@tests) {
 	ok($plugin->status == $test->{status}, "status code (got:".$plugin->status." exp:".$test->{status}.")");
 	print "[".$plugin->message."]\n";
 	ok($plugin->message eq $test->{message}, "status message");
+
+	if (!$test->{perfdata} eq '' || !$plugin->perfdata eq '') {
+        print "[".$plugin->perfdata."]\n";
+    }
+	ok($plugin->perfdata eq $test->{perfdata}, "performance data");
+
+	if (!$test->{longoutput} eq '' || !$plugin->longoutput eq '') {
+	    print "[".$plugin->longoutput."]\n";
+    }
+	ok($plugin->longoutput eq $test->{longoutput}, "long output");
 }

--- a/t/data/megacli/issue39/batteries.bbustatus.1
+++ b/t/data/megacli/issue39/batteries.bbustatus.1
@@ -1,0 +1,48 @@
+                                     
+BBU status for Adapter: 0
+
+BatteryType: iBBU
+Voltage: 3923 mV
+Current: 0 mA
+Temperature: 18 C
+Battery State     : Operational
+
+BBU Firmware Status:
+
+  Charging Status              : None
+  Voltage                                 : OK
+  Temperature                             : OK
+  Learn Cycle Requested	                  : No
+  Learn Cycle Active                      : No
+  Learn Cycle Status                      : OK
+  Learn Cycle Timeout                     : No
+  I2c Errors Detected                     : No
+  Battery Pack Missing                    : No
+  Battery Replacement required            : No
+  Remaining Capacity Low                  : No
+  Periodic Learn Required                 : No
+  Transparent Learn                       : No
+  No space to cache offload               : No
+  Pack is about to fail & should be replaced : No
+  Cache Offload premium feature required  : No
+  Module microcode update required        : No
+
+
+GasGuageStatus:
+  Fully Discharged        : No
+  Fully Charged           : No
+  Discharging             : Yes
+  Initialized             : Yes
+  Remaining Time Alarm    : No
+  Discharge Terminated    : No
+  Over Temperature        : No
+  Charging Terminated     : No
+  Over Charged            : No
+  Relative State of Charge: 67 %
+  Charger System State: 49169
+  Charger System Ctrl: 0
+  Charging current: 512 mA
+  Absolute state of charge: 65 %
+  Max Error: 2 %
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.bbustatus.2
+++ b/t/data/megacli/issue39/batteries.bbustatus.2
@@ -1,0 +1,52 @@
+                                     
+BBU status for Adapter: 0
+
+BatteryType: iBBU
+Voltage: 4053 mV
+Current: 0 mA
+Temperature: 26 C
+
+Battery State     : Operational
+
+BBU Firmware Status:
+
+  Charging Status              : None
+  Voltage                                 : OK
+  Temperature                             : OK
+  Learn Cycle Requested                   : No
+  Learn Cycle Active                      : No
+  Learn Cycle Status                      : OK
+  Learn Cycle Timeout                     : No
+  I2c Errors Detected                     : No
+  Battery Pack Missing                    : No
+  Battery Replacement required            : Yes
+  Remaining Capacity Low                  : Yes
+  Periodic Learn Required                 : No
+  Transparent Learn                       : No
+  No space to cache offload               : No
+  Pack is about to fail & should be replaced : No
+  Cache Offload premium feature required  : No
+  Module microcode update required        : No
+
+
+
+GasGuageStatus:
+  Fully Discharged        : No
+  Fully Charged           : Yes
+  Discharging             : Yes
+  Initialized             : Yes
+  Remaining Time Alarm    : No
+  Remaining Capacity Alarm: No
+  Discharge Terminated    : No
+  Over Temperature        : No
+  Charging Terminated     : No
+  Over Charged            : No
+
+Relative State of Charge: 97 %
+Charger System State: 49168
+Charger System Ctrl: 0
+Charging current: 0 mA
+Absolute state of charge: 46 %
+Max Error: 2 %
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.bbustatus.3
+++ b/t/data/megacli/issue39/batteries.bbustatus.3
@@ -1,0 +1,48 @@
+                                     
+BBU status for Adapter: 0
+
+BatteryType: iBBU
+Voltage: 4090 mV
+Current: 0 mA
+Temperature: 22 C
+Battery State     : Non Operational
+
+BBU Firmware Status:
+
+  Charging Status              : Charging
+  Voltage                                 : OK
+  Temperature                             : OK
+  Learn Cycle Requested	                  : Yes
+  Learn Cycle Active                      : Yes
+  Learn Cycle Status                      : OK
+  Learn Cycle Timeout                     : No
+  I2c Errors Detected                     : No
+  Battery Pack Missing                    : No
+  Battery Replacement required            : No
+  Remaining Capacity Low                  : No
+  Periodic Learn Required                 : No
+  Transparent Learn                       : No
+  No space to cache offload               : No
+  Pack is about to fail & should be replaced : No
+  Cache Offload premium feature required  : No
+  Module microcode update required        : No
+
+
+GasGuageStatus:
+  Fully Discharged        : No
+  Fully Charged           : No
+  Discharging             : Yes
+  Initialized             : Yes
+  Remaining Time Alarm    : No
+  Discharge Terminated    : No
+  Over Temperature        : No
+  Charging Terminated     : No
+  Over Charged            : No
+  Relative State of Charge: 100 %
+  Charger System State: 49169
+  Charger System Ctrl: 0
+  Charging current: 0 mA
+  Absolute state of charge: 76 %
+  Max Error: 25 %
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.ldinfo.1
+++ b/t/data/megacli/issue39/batteries.ldinfo.1
@@ -1,0 +1,25 @@
+                                     
+
+Adapter 0 -- Virtual Drive Information:
+Virtual Drive: 0 (Target Id: 0)
+Name                :
+RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
+Size                : 557.861 GB
+Is VD emulated      : No
+Mirror Data         : 557.861 GB
+State               : Optimal
+Strip Size          : 64 KB
+Number Of Drives    : 2
+Span Depth          : 1
+Default Cache Policy: WriteBack, ReadAdaptive, Cached, Write Cache OK if Bad BBU
+Current Cache Policy: WriteBack, ReadAdaptive, Cached, Write Cache OK if Bad BBU
+Default Access Policy: Read/Write
+Current Access Policy: Read/Write
+Disk Cache Policy   : Disk's Default
+Encryption Type     : None
+Bad Blocks Exist: No
+Is VD Cached: No
+
+
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.ldinfo.2
+++ b/t/data/megacli/issue39/batteries.ldinfo.2
@@ -1,0 +1,25 @@
+                                     
+
+Adapter 0 -- Virtual Drive Information:
+Virtual Drive: 0 (Target Id: 0)
+Name                :
+RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
+Size                : 931.0 GB
+Is VD emulated      : No
+Mirror Data         : 931.0 GB
+State               : Optimal
+Strip Size          : 64 KB
+Number Of Drives    : 2
+Span Depth          : 1
+Default Cache Policy: WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU
+Current Cache Policy: WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU
+Default Access Policy: Read/Write
+Current Access Policy: Read/Write
+Disk Cache Policy   : Disk's Default
+Encryption Type     : None
+Bad Blocks Exist: No
+Is VD Cached: No
+
+
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.ldinfo.3
+++ b/t/data/megacli/issue39/batteries.ldinfo.3
@@ -1,0 +1,25 @@
+                                     
+
+Adapter 0 -- Virtual Drive Information:
+Virtual Drive: 0 (Target Id: 0)
+Name                :
+RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
+Size                : 931.0 GB
+Is VD emulated      : No
+Mirror Data         : 931.0 GB
+State               : Optimal
+Strip Size          : 64 KB
+Number Of Drives    : 2
+Span Depth          : 1
+Default Cache Policy: WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU
+Current Cache Policy: WriteBack, ReadAdaptive, Direct, No Write Cache if Bad BBU
+Default Access Policy: Read/Write
+Current Access Policy: Read/Write
+Disk Cache Policy   : Disk's Default
+Encryption Type     : None
+Bad Blocks Exist: No
+Is VD Cached: No
+
+
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.pdlist.1
+++ b/t/data/megacli/issue39/batteries.pdlist.1
@@ -1,0 +1,105 @@
+                                     
+Adapter #0
+
+Enclosure Device ID: 252
+Slot Number: 0
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 0
+Enclosure position: N/A
+Device Id: 8
+WWN: 5000C5005F23ECE8
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 558.911 GB [0x45dd2fb0 Sectors]
+Non Coerced Size: 558.411 GB [0x45cd2fb0 Sectors]
+Coerced Size: 557.861 GB [0x45bb9000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0001
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x5000c5005f23ece9
+SAS Address(1): 0x0
+Connected Port Number: 0(path0) 
+Inquiry Data: SEAGATE ST600MM0026     0001S0M03T5C            
+FDE Capable: Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :32C (89.60 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+Enclosure Device ID: 252
+Slot Number: 1
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 1
+Enclosure position: N/A
+Device Id: 7
+WWN: 50000394A81082E5
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 558.911 GB [0x45dd2fb0 Sectors]
+Non Coerced Size: 558.411 GB [0x45cd2fb0 Sectors]
+Coerced Size: 557.861 GB [0x45bb9000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0101
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x50000394a81082e6
+SAS Address(1): 0x0
+Connected Port Number: 1(path0) 
+Inquiry Data: TOSHIBA AL13SEB600      010133A0A00ZFTR8        
+FDE Capable: Not Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :32C (89.60 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.pdlist.2
+++ b/t/data/megacli/issue39/batteries.pdlist.2
@@ -1,0 +1,105 @@
+                                     
+Adapter #0
+
+Enclosure Device ID: 6
+Slot Number: 0
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 0
+Enclosure position: 1
+Device Id: 4
+WWN: 5000039438C87049
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 931.512 GB [0x74706db0 Sectors]
+Non Coerced Size: 931.012 GB [0x74606db0 Sectors]
+Coerced Size: 931.0 GB [0x74600000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0106
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x5000039438c8704a
+SAS Address(1): 0x0
+Connected Port Number: 0(path0) 
+Inquiry Data: TOSHIBA MK1001TRKB      01068280A00QFM16        
+FDE Capable: Not Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :30C (86.00 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+Enclosure Device ID: 6
+Slot Number: 1
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 1
+Enclosure position: 1
+Device Id: 5
+WWN: 5000039438C86FE9
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 931.512 GB [0x74706db0 Sectors]
+Non Coerced Size: 931.012 GB [0x74606db0 Sectors]
+Coerced Size: 931.0 GB [0x74600000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0106
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x5000039438c86fea
+SAS Address(1): 0x0
+Connected Port Number: 0(path0) 
+Inquiry Data: TOSHIBA MK1001TRKB      01068280A003FM16        
+FDE Capable: Not Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :30C (86.00 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+
+Exit Code: 0x00

--- a/t/data/megacli/issue39/batteries.pdlist.3
+++ b/t/data/megacli/issue39/batteries.pdlist.3
@@ -1,0 +1,105 @@
+                                     
+Adapter #0
+
+Enclosure Device ID: 6
+Slot Number: 0
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 0
+Enclosure position: 1
+Device Id: 4
+WWN: 5000039438C87049
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 931.512 GB [0x74706db0 Sectors]
+Non Coerced Size: 931.012 GB [0x74606db0 Sectors]
+Coerced Size: 931.0 GB [0x74600000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0106
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x5000039438c8704a
+SAS Address(1): 0x0
+Connected Port Number: 0(path0) 
+Inquiry Data: TOSHIBA MK1001TRKB      01068280A00QFM16        
+FDE Capable: Not Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :30C (86.00 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+Enclosure Device ID: 6
+Slot Number: 1
+Drive's postion: DiskGroup: 0, Span: 0, Arm: 1
+Enclosure position: 1
+Device Id: 5
+WWN: 5000039438C86FE9
+Sequence Number: 2
+Media Error Count: 0
+Other Error Count: 0
+Predictive Failure Count: 0
+Last Predictive Failure Event Seq Number: 0
+PD Type: SAS
+
+Raw Size: 931.512 GB [0x74706db0 Sectors]
+Non Coerced Size: 931.012 GB [0x74606db0 Sectors]
+Coerced Size: 931.0 GB [0x74600000 Sectors]
+Emulated Drive: No
+Firmware state: Online, Spun Up
+Commissioned Spare : No
+Emergency Spare : No
+Device Firmware Level: 0106
+Shield Counter: 0
+Successful diagnostics completion on :  N/A
+SAS Address(0): 0x5000039438c86fea
+SAS Address(1): 0x0
+Connected Port Number: 0(path0) 
+Inquiry Data: TOSHIBA MK1001TRKB      01068280A003FM16        
+FDE Capable: Not Capable
+FDE Enable: Disable
+Secured: Unsecured
+Locked: Unlocked
+Needs EKM Attention: No
+Foreign State: None 
+Device Speed: 6.0Gb/s 
+Link Speed: 6.0Gb/s 
+Media Type: Hard Disk Device
+Drive Temperature :30C (86.00 F)
+PI Eligibility:  No 
+Drive is formatted for PI information:  No
+PI: No PI
+Port-0 :
+Port status: Active
+Port's Linkspeed: 6.0Gb/s 
+Port-1 :
+Port status: Active
+Port's Linkspeed: Unknown 
+Drive has flagged a S.M.A.R.T alert : No
+
+
+
+
+Exit Code: 0x00


### PR DESCRIPTION
Here are the test data for pull request #39.
This pull request also fix a bug introduced by PR #46: when battery state is "Non Operational", check_raid must return "CRITICAL", not "OK".

Happy :christmas_tree: 
