### PR TITLE
add active method to dmraid plugin

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -3479,6 +3479,12 @@ sub commands {
 	}
 }
 
+sub active ($) {
+        my ($this) = @_;
+        # check if dmraid is empty
+        return  keys ( %{$this->parse} ) > 0;
+}
+
 sub sudo {
 	my ($this, $deep) = @_;
 	# quick check when running check


### PR DESCRIPTION
add active method to dmraid plugin. This prevent plugin error when dmraid binary is installed but no dmraid raid is present.
