### PR TITLE
Fixed parsing of channel information

### DIFF
--- a/t/check_arcconf.t
+++ b/t/check_arcconf.t
@@ -6,7 +6,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 42;
+use Test::More tests => 47;
 use test;
 
 # NOTE: this plugin has side effect of changing dir
@@ -63,6 +63,12 @@ my @tests = (
 		getstatus => 'issue55/arcconf-getstatus.out',
 		getconfig => 'issue55/arcconf-getconfig.out',
 		message => 'Controller:Optimal, Logical Device 0(plop):Optimal, Drives: Y2O483PAS,Y2O3MYTGS,Y2O3M8RGS=Online S1F02BSH=Online (JBOD)',
+	},
+	{
+		status => OK,
+		getstatus => 'issue67/getstatus',
+		getconfig => 'issue67/getconfig',
+		message => 'Controller:Optimal, Logical Device 0(RAID):Optimal, Drives: 3KS5ABTV0000970648ZZ,3KS5SD1P00009718B64U=Online',
 	},
 );
 

--- a/t/data/arcconf/issue67/getconfig
+++ b/t/data/arcconf/issue67/getconfig
@@ -1,0 +1,104 @@
+Controllers found: 1
+----------------------------------------------------------------------
+Controller information
+----------------------------------------------------------------------
+   Controller Status                        : Optimal
+   Channel description                      : SCSI
+   Controller Model                         : Adaptec 2020ZCR
+   Controller Serial Number                 : BAD0
+   Physical Slot                            : 2
+   Installed memory                         : 64 MB
+   Copyback                                 : Disabled
+   Background consistency check             : Disabled
+   Automatic Failover                       : Enabled
+   Stayawake period                         : Disabled
+   Spinup limit internal drives             : 0
+   Spinup limit external drives             : 0
+   Defunct disk drive count                 : 0
+   Logical devices/Failed/Degraded          : 1/0/0
+   --------------------------------------------------------
+   Controller Version Information
+   --------------------------------------------------------
+   BIOS                                     : 4.2-1 (7373)
+   Firmware                                 : 4.2-1 (7373)
+   Driver                                   : 1.1-7 (28000)
+   Boot Flash                               : 0.0-0 (0)
+   --------------------------------------------------------
+   Controller Battery Information
+   --------------------------------------------------------
+   Status                                   : Not Installed
+
+----------------------------------------------------------------------
+Logical device information
+----------------------------------------------------------------------
+Logical device number 0
+   Logical device name                      : RAID
+   RAID level                               : 1
+   Status of logical device                 : Optimal
+   Size                                     : 139981 MB
+   Read-cache mode                          : Disabled
+   Write-cache mode                         : Disabled (write-through)
+   Write-cache setting                      : Disabled (write-through)
+   Partitioned                              : Yes
+   Protected by Hot-Spare                   : No
+   Bootable                                 : Yes
+   Failed stripes                           : No
+   Power settings                           : Disabled
+   --------------------------------------------------------
+   Logical device segment information
+   --------------------------------------------------------
+   Segment 0                                : Present (0,0) 3KS5ABTV0000970648ZZ
+   Segment 1                                : Present (0,1) 3KS5SD1P00009718B64U
+
+
+----------------------------------------------------------------------
+Physical Device information
+----------------------------------------------------------------------
+   Channel #0:
+      Transfer Speed                        : Ultra320
+      Initiator at SCSI ID 7
+      Device #0
+         Device is a Hard drive
+         State                              : Online
+         Supported                          : Yes
+         Transfer Speed                     : Ultra320
+         Reported Channel,Device(T:L)       : 0,0(0:0)
+         Vendor                             : SEAGATE
+         Model                              : ST3146707LC
+         Firmware                           : 0005
+         Serial number                      : 3KS5ABTV0000970648ZZ
+         Size                               : 140014 MB
+         Write Cache                        : Unknown
+         FRU                                : None
+         S.M.A.R.T.                         : No
+         S.M.A.R.T. warnings                : 0
+      Device #1
+         Device is a Hard drive
+         State                              : Online
+         Supported                          : Yes
+         Transfer Speed                     : Ultra320
+         Reported Channel,Device(T:L)       : 0,1(1:0)
+         Vendor                             : SEAGATE
+         Model                              : ST3146707LC
+         Firmware                           : 0005
+         Serial number                      : 3KS5SD1P00009718B64U
+         Size                               : 140014 MB
+         Write Cache                        : Unknown
+         FRU                                : None
+         S.M.A.R.T.                         : No
+         S.M.A.R.T. warnings                : 0
+      Device #6
+         Device is an Enclosure
+         Type                               : SAF-TE
+         Vendor                             : SUPER
+         Model                              : GEM318
+         Firmware                           : 0
+         Status of Enclosure
+            Temperature status              : Normal
+   Channel #1:
+      Transfer Speed                        : Ultra320
+      Initiator at SCSI ID 7
+      No physical drives attached
+
+
+Command completed successfully.

--- a/t/data/arcconf/issue67/getstatus
+++ b/t/data/arcconf/issue67/getstatus
@@ -1,0 +1,4 @@
+Controllers found: 1
+   Current operation              : None
+
+Command completed successfully.


### PR DESCRIPTION
The fix assumes channel number 0 until an actual Channel # is mentioned. 
Tested with arcconf Version 7.0 (B18781) and Adaptec 2020ZCR. The GETCONFIG output of this version breaks the assumption that Status of Enclosure is the last data to parse (line 2320-2327 in the original check_raid.pl), so I accomodated that by matching known enclosure status information from the test data.
