### PR TITLE
Add --check=STATE to set state if RAID is checking

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -96,6 +96,9 @@ my (%ERRORS) = (OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3);
 # status to set when RAID is in resync state
 our $resync_status = $ERRORS{WARNING};
 
+# status to set when RAID is in check state
+our $check_status = $ERRORS{OK};
+
 # status to set when BBU is in learning cycle.
 our $bbulearn_status = $ERRORS{WARNING};
 
@@ -209,6 +212,14 @@ sub ok {
 sub resync {
 	my ($this) = @_;
 	$this->status($resync_status);
+	return $this;
+}
+
+# helper to set status for check
+# returns $this to allow fluent api
+sub check_status {
+	my ($this) = @_;
+	$this->status($check_status);
 	return $this;
 }
 
@@ -675,8 +686,11 @@ sub parse {
 		# linux-2.6.33/drivers/md/md.c, status_resync
 		# [==>..................]  resync = 13.0% (95900032/732515712) finish=175.4min speed=60459K/sec
 		# [=>...................]  check =  8.8% (34390144/390443648) finish=194.2min speed=30550K/sec
-		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|check|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
+		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
 			$md{resync_status} = "$action:$perc $speed ETA: $eta";
+			next;
+		} elsif (($perc, $eta, $speed) = m{check\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
+			$md{check_status} = "check:$perc $speed ETA: $eta";
 			next;
 		}
 
@@ -717,6 +731,10 @@ sub check {
 		} elsif ($md{resync_status}) {
 			$this->resync;
 			$s .= "$md{status} ($md{resync_status})";
+
+		} elsif ($md{check_status}) {
+			$this->check_status;
+			$s .= "$md{status} ($md{check_status})";
 
 		} elsif ($md{status} =~ /_/) {
 			$this->critical;
@@ -3656,6 +3674,8 @@ sub print_usage() {
 	"    Lists active plugins",
 	" --resync=STATE",
 	"    Return STATE if RAID is in resync state. Defaults to WARNING",
+	" --check=STATE",
+	"    Return STATE if RAID is in check state. Defaults to OK",
 	" --noraid=STATE",
 	"    Return STATE if no RAID controller is found. Defaults to UNKNOWN",
 	" --bbulearn=STATE",
@@ -3788,6 +3808,7 @@ GetOptions(
 	'S' => \$opt_S, 'sudoers' => \$opt_S,
 	'W' => \$opt_W, 'warnonly' => \$opt_W,
 	'resync=s' => sub { setstate(\$plugin::resync_status, @_); },
+	'check=s' => sub { setstate(\$plugin::check_status, @_); },
 	'noraid=s' => sub { setstate(\$opt_O, @_); },
 	'bbulearn=s' => sub { setstate(\$plugin::bbulearn_status, @_); },
 	'bbu-monitoring' => \$plugin::bbu_monitoring,


### PR DESCRIPTION
Allows the user to set the status if RAID is found in a checking state.
Defaults to OK.

Admittedly, I'm horrible at Perl, and pretty much just copied stuff from 910e76d, so feel free to berate me into making additional changes to this PR to make it not completely terrible.
