### PR TITLE
Fixed behaviour of --noraid option

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -3844,7 +3844,11 @@ foreach my $pn (@plugins) {
 		$message .= "$pn:[Plugin error]";
 		next;
 	}
-	$status = $plugin->status if $plugin->status > $status;
+	if ($plugin->message or $opt_O == $ERRORS{UNKNOWN}) {
+	  $status = $plugin->status if $plugin->status > $status;
+	} else {
+	  $status = $opt_O if $opt_O > $status;
+	} 
 	$message .= '; ' if $message;
 	$message .= "$pn:[".$plugin->message."]";
 	$message .= ' | ' . $plugin->perfdata if $plugin->perfdata;
@@ -3862,8 +3866,8 @@ if ($message) {
 		print "UNKNOWN: ";
 	}
 	print "$message\n";
-} elsif ($opt_O) {
-	$status = $ERRORS{OK};
+} elsif ($opt_O != $ERRORS{UNKNOWN}) {
+	$status = $opt_O;
 	print "No RAID configuration found\n";
 } else {
 	$status = $ERRORS{UNKNOWN};


### PR DESCRIPTION
Option did not work corretly when more than 1 RAID type was present -
when 1 RAID configuration was found (SW in our case) and
the second type was not used (HW in our case) the scrit returned unknown
regardless of chosen option.

Also fixed the 'if ($opt_O)' condition - was false only in case of
ERRORS{OK}.
