### PR TITLE
fixed false critical by using pass trough disks on areca controller

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -3488,6 +3488,9 @@ sub check {
 		} elsif ($usage =~ /HotSpare/) {
 			# hotspare is OK
 			push(@{$drivestatus{$array_name}}, $id);
+		} elsif ($usage =~ /Pass Through/) {
+			# Pass Through is OK
+			push(@{$drivestatus{$array_name}}, $id);
 		} else {
 			push(@{$drivestatus{$array_name}}, $id);
 			$this->critical;


### PR DESCRIPTION
myhost:/tmp/nagios-plugin-check_raid# perl t/check_areca.t 
1..15
ok 1 - plugin created
ok 2 - check ran
ok 3 - status code set
ok 4 - status code (got:0 exp:0)
[Array#1(Raid Set # 000): Normal, Drive Assignment: 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,31,32=Array#1 30=HotSpare]
ok 5 - status message
ok 6 - plugin created
ok 7 - check ran
ok 8 - status code set
ok 9 - status code (got:2 exp:2)
[Array#1(data): Rebuilding, Drive Assignment: 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15=Array#1 16=Failed]
ok 10 - status message
ok 11 - plugin created
ok 12 - check ran
ok 13 - status code set
ok 14 - status code (got:0 exp:0)
[Array#1(Raid Set # 00): Normal, Drive Assignment: 1,2,3,4,5,6,7,8,9=Array#1]
ok 15 - status message
