### PR TITLE
mdstat: do not trigger WARN when checking (even multiple) arrays by default

### DIFF
--- a/t/check_mdstat.t
+++ b/t/check_mdstat.t
@@ -7,7 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 use constant INACTIVE_TESTS => 2;
-use constant ACTIVE_TESTS => 17;
+use constant ACTIVE_TESTS => 18;
 use Test::More tests => ACTIVE_TESTS * 6 + INACTIVE_TESTS * 2;
 use test;
 
@@ -51,13 +51,17 @@ my @tests = (
 		message => 'md1(927.52 GiB raid1):_U (resync=DELAYED), md0(203.81 MiB raid1):_U (recovery:3.9% 12K/sec ETA: 267.0min)',
 	},
 	# issues #23 and #24
-	{ input => 'pr24', status => WARNING, resync_status => WARNING,
+	{ input => 'pr24', status => WARNING, check_status => WARNING,
 		active => 1,
 		message => 'md2(2.73 TiB raid1):UU (check:98.3% 9854K/sec ETA: 81.7min), md1(511.99 MiB raid1):UU, md0(2.00 GiB raid1):UU',
 	},
-	{ input => 'pr24', status => OK, resync_status => OK,
+	{ input => 'pr24', status => OK, check_status => OK,
 		active => 1,
 		message => 'md2(2.73 TiB raid1):UU (check:98.3% 9854K/sec ETA: 81.7min), md1(511.99 MiB raid1):UU, md0(2.00 GiB raid1):UU',
+	},
+	{ input => 'pr77', status => OK, check_status => OK,
+		active => 1,
+		message => 'md1(445.64 GiB raid1):UU (check=DELAYED), md0(20.00 GiB raid1):UU (check:6.4% 97293K/sec ETA: 3.3min)',
 	},
 	{ input => 'issue34', status => OK,
 		active => 1,
@@ -91,12 +95,18 @@ my @tests = (
 
 # save default value
 my $saved_resync_status = $plugin::resync_status;
+my $saved_check_status = $plugin::check_status;
 
 foreach my $test (@tests) {
 	if (defined $test->{resync_status}) {
 		$plugin::resync_status = $test->{resync_status};
 	} else {
 		$plugin::resync_status = $saved_resync_status;
+	}
+	if (defined $test->{check_status}) {
+		$plugin::check_status = $test->{check_status};
+	} else {
+		$plugin::check_status = $saved_check_status;
 	}
 	my $plugin = mdstat->new(
 		commands => {

--- a/t/data/mdstat/pr77
+++ b/t/data/mdstat/pr77
@@ -1,0 +1,12 @@
+Personalities : [raid1]
+md1 : active raid1 sda2[0] sdb2[1]
+      467282752 blocks super 1.1 [2/2] [UU]
+        resync=DELAYED
+      bitmap: 0/4 pages [0KB], 65536KB chunk
+
+md0 : active raid1 sda1[0] sdb1[1]
+      20971392 blocks super 1.0 [2/2] [UU]
+      [=>...................]  check =  6.4% (1362112/20971392) finish=3.3min speed=97293K/sec
+      bitmap: 1/1 pages [4KB], 65536KB chunk
+
+unused devices: <none>


### PR DESCRIPTION
This fixes behavior when one or multiple devices are beining checked and the plugin triggers WARN. It is based on pull request https://github.com/glensc/nagios-plugin-check_raid/pull/69 but fixes also the case where there is more then one array scheduled to be checked. In such case, the mdstat output marks the scheduled arrays as "resync=DELAYED", which would previously trigger warning. We handle this case specially by checking if there is more than one array and if at least one of the other arrays are being checked. If so, we assume that resync=DELAYED state is because of scheduled check and do not trigger WARN.
