### PR TITLE
checking an mdraid is not a problem, so don't complain

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -675,7 +675,7 @@ sub parse {
 		# linux-2.6.33/drivers/md/md.c, status_resync
 		# [==>..................]  resync = 13.0% (95900032/732515712) finish=175.4min speed=60459K/sec
 		# [=>...................]  check =  8.8% (34390144/390443648) finish=194.2min speed=30550K/sec
-		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|check|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
+		if (my($action, $perc, $eta, $speed) = m{(resync|recovery|reshape)\s+=\s+([\d.]+%) \(\d+/\d+\) finish=([\d.]+min) speed=(\d+K/sec)}) {
 			$md{resync_status} = "$action:$perc $speed ETA: $eta";
 			next;
 		}


### PR DESCRIPTION
I get WARNING mails every weekend simply because the mdraid is being checked.  This is normal operation and not in any way a warning condition, so don't treat it as WARNING.
