### PR TITLE
Enable sds support

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -614,6 +614,14 @@ sub check {
 				push(@status, "$d:$sd:$s");
 			}
 		}
+		if ( defined $d && $d =~ /hsp/ ) {
+			if ( /(c[0-9]+t[0-9]+d[0-9]+s[0-9]+)\s+(\w+)/ ) {
+				$sd = $1;
+				my  $s = $2;
+				$this->warning if ($s !~ /Available/);
+				push(@status, "$d:$sd:$s");
+			}
+		}
 	}
 	close $fh;
 

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -604,6 +604,7 @@ sub check {
 	foreach (@{$this->{output}} ) {
 		if (/^(\S+):/) { $d = $1; $sd = ''; next; }
 		if (/Submirror \d+:\s+(\S+)/) { $sd = $1; next; }
+		if (/Device:\s+(\S+)/) { $sd = $1; next; }
 		if (my($s) = /State: (\S.+\w)/) {
 			if ($sd and $this->valid($sd) and $this->valid($d)) {
 				if ($s =~ /Okay/i) {

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -559,6 +559,7 @@ sub program_names {
 sub commands {
 	{
 		'status' => ['-|', '@CMD'],
+		'snapshot' => ['>&2', '@CMD', '-p' ],
 	}
 }
 
@@ -569,6 +570,24 @@ sub sudo {
 
 	my $cmd = $this->{program};
 	"CHECK_RAID ALL=(root) NOPASSWD: $cmd"
+}
+
+sub active ($) {
+        my ($this) = @_;
+
+        # program not found
+        return 0 unless $this->{program};
+
+        return $this->check_metadb > 0;
+}
+
+sub check_metadb {
+        my $this = shift;
+        my $fh = $this->cmd('snapshot');
+        while (<$fh>) {
+                return 0 if (/there are no existing databases/);
+        }
+        return 1;
 }
 
 sub check {

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -558,7 +558,7 @@ sub program_names {
 
 sub commands {
 	{
-		'status' => ['-|', '@CMD'],
+		'status' => [>&2', '@CMD'],
 	}
 }
 

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -558,7 +558,7 @@ sub program_names {
 
 sub commands {
 	{
-		'status' => [>&2', '@CMD'],
+		'status' => ['>&2', '@CMD'],
 	}
 }
 

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -550,8 +550,7 @@ package metastat;
 # Solaris, software RAID
 use base 'plugin';
 
-# Status: BROKEN: no test data
-#push(@utils::plugins, __PACKAGE__);
+push(@utils::plugins, __PACKAGE__);
 
 sub program_names {
 	__PACKAGE__;
@@ -564,7 +563,11 @@ sub commands {
 }
 
 sub sudo {
-	my $cmd = shift->{program};
+	my ($this, $deep) = @_;
+	# quick check when running check
+	return 1 unless $deep;
+
+	my $cmd = $this->{program};
 	"CHECK_RAID ALL=(root) NOPASSWD: $cmd"
 }
 
@@ -580,8 +583,8 @@ sub check {
 	while (<$fh>) {
 		if (/^(\S+):/) { $d = $1; $sd = ''; next; }
 		if (/Submirror \d+:\s+(\S+)/) { $sd = $1; next; }
-		if (my($s) = /State: (\S.+)/) {
-			if ($sd and valid($sd) and valid($d)) {
+		if (my($s) = /State: (\S.+\w)/) {
+			if ($sd and $this->valid($sd) and $this->valid($d)) {
 				if ($s =~ /Okay/i) {
 					# no worries...
 				} elsif ($s =~ /Resync/i) {
@@ -597,7 +600,7 @@ sub check {
 
 	return unless @status;
 
-	$this->message(join(' ', @status));
+	$this->ok->message(join(', ', @status));
 }
 
 package megaide;

--- a/t/data/metastat/check_metastat.t
+++ b/t/data/metastat/check_metastat.t
@@ -2,34 +2,6 @@ perl -MTest::Harness -e 'runtests @ARGV' t/*.t
 t/check_afacli......ok
 t/check_arcconf.....ok
 t/check_areca.......ok
-t/check_cciss.......ok 1/60readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
-readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
-	(Are you trying to call readline() on dirhandle $fh?)
 t/check_cciss.......ok
 t/check_cmdtool2....ok
 t/check_dmraid......ok
@@ -50,5 +22,4 @@ t/enabled...........ok
 t/status............ok
 t/sudo..............ok
 All tests successful.
-Files=22, Tests=648,  3 wallclock secs ( 1.94 cusr +  0.83 csys =  2.77 CPU)
-
+Files=22, Tests=648,  3 wallclock secs ( 2.30 cusr +  0.73 csys =  3.03 CPU)

--- a/t/data/metastat/check_metastat.t
+++ b/t/data/metastat/check_metastat.t
@@ -1,0 +1,54 @@
+perl -MTest::Harness -e 'runtests @ARGV' t/*.t
+t/check_afacli......ok
+t/check_arcconf.....ok
+t/check_areca.......ok
+t/check_cciss.......ok 1/60readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+readline() on unopened filehandle $fh at t//../check_raid.pl line 3237.
+	(Are you trying to call readline() on dirhandle $fh?)
+t/check_cciss.......ok
+t/check_cmdtool2....ok
+t/check_dmraid......ok
+t/check_dpt_i2o.....ok
+t/check_gdth........ok
+t/check_hpacucli....ok
+t/check_hp_msa......ok
+t/check_ips.........ok
+t/check_lsscsi......ok
+t/check_mdstat......ok
+t/check_megacli.....ok
+t/check_megarc......ok
+t/check_mpt.........ok
+t/check_sas2ircu....ok
+t/check_smartctl....ok
+t/check_tw_cli......ok
+t/enabled...........ok
+t/status............ok
+t/sudo..............ok
+All tests successful.
+Files=22, Tests=648,  3 wallclock secs ( 1.94 cusr +  0.83 csys =  2.77 CPU)
+

--- a/t/data/metastat/metastat-mirrors-with-hotspares
+++ b/t/data/metastat/metastat-mirrors-with-hotspares
@@ -1,0 +1,195 @@
+metastat
+d9: Mirror
+    Submirror 0: d19
+      State: Okay
+    Submirror 1: d29
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 430007232 blocks (205 GB)
+
+d19: Submirror of d9
+    State: Okay
+    Hot spare pool: hsp001
+    Size: 430007232 blocks (205 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t2d0s0          0     No            Okay   Yes
+    Stripe 1:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t4d0s0      20352     No            Okay   Yes
+
+
+d29: Submirror of d9
+    State: Okay
+    Hot spare pool: hsp002
+    Size: 430007232 blocks (205 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t2d0s0          0     No            Okay   Yes
+    Stripe 1:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t4d0s0      20352     No            Okay   Yes
+
+
+d8: Mirror
+    Submirror 0: d18
+      State: Okay
+    Submirror 1: d28
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 430007232 blocks (205 GB)
+
+d18: Submirror of d8
+    State: Okay
+    Hot spare pool: hsp001
+    Size: 430007232 blocks (205 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t1d0s0          0     No            Okay   Yes
+    Stripe 1:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t3d0s0      20352     No            Okay   Yes
+
+
+d28: Submirror of d8
+    State: Okay
+    Hot spare pool: hsp002
+    Size: 430007232 blocks (205 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t1d0s0          0     No            Okay   Yes
+    Stripe 1:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t3d0s0      20352     No            Okay   Yes
+
+
+d4: Mirror
+    Submirror 0: d14
+      State: Okay
+    Submirror 1: d24
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 105372480 blocks (50 GB)
+
+d14: Submirror of d4
+    State: Okay
+    Size: 105372480 blocks (50 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s4          0     No            Okay   Yes
+
+
+d24: Submirror of d4
+    State: Okay
+    Size: 105372480 blocks (50 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t0d0s4          0     No            Okay   Yes
+
+
+d3: Mirror
+    Submirror 0: d13
+      State: Okay
+    Submirror 1: d23
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 20972736 blocks (10 GB)
+
+d13: Submirror of d3
+    State: Okay
+    Size: 20972736 blocks (10 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s3          0     No            Okay   Yes
+
+
+d23: Submirror of d3
+    State: Okay
+    Size: 20972736 blocks (10 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t0d0s3          0     No            Okay   Yes
+
+
+d1: Mirror
+    Submirror 0: d11
+      State: Okay
+    Submirror 1: d21
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 8395200 blocks (4.0 GB)
+
+d11: Submirror of d1
+    State: Okay
+    Size: 8395200 blocks (4.0 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s1          0     No            Okay   Yes
+
+
+d21: Submirror of d1
+    State: Okay
+    Size: 8395200 blocks (4.0 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t0d0s1          0     No            Okay   Yes
+
+
+d0: Mirror
+    Submirror 0: d10
+      State: Okay
+    Submirror 1: d20
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 8395200 blocks (4.0 GB)
+
+d10: Submirror of d0
+    State: Okay
+    Size: 8395200 blocks (4.0 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s0          0     No            Okay   Yes
+
+
+d20: Submirror of d0
+    State: Okay
+    Size: 8395200 blocks (4.0 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c2t0d0s0          0     No            Okay   Yes
+
+
+hsp001: 1 hot spare
+        Device     Status      Length           Reloc
+        c1t5d0s0   Available    286678272 blocks        Yes
+
+hsp002: 1 hot spare
+        Device     Status      Length           Reloc
+        c2t5d0s0   Available    286678272 blocks        Yes
+
+Device Relocation Information:
+Device   Reloc  Device ID
+c2t2d0   Yes    id1,ssd@n20000000876d4b8d
+c2t4d0   Yes    id1,ssd@n2000001862f403ce
+c2t1d0   Yes    id1,ssd@n500000e010ee4d30
+c2t3d0   Yes    id1,ssd@n2000001862f1fbc6
+c1t2d0   Yes    id1,ssd@n500000e010ee0f50
+c1t4d0   Yes    id1,ssd@n2000001862f403be
+c1t1d0   Yes    id1,ssd@n500000e010ee3250
+c1t3d0   Yes    id1,ssd@n2000001862f405a4
+c2t0d0   Yes    id1,ssd@n500000e010ee3710
+c1t0d0   Yes    id1,ssd@n20000011c67a8a31
+c1t5d0   Yes    id1,ssd@n2000001862d8d283
+c2t5d0   Yes    id1,ssd@n2000001862f4042e

--- a/t/data/metastat/metastat-snapshot-mirrors
+++ b/t/data/metastat/metastat-snapshot-mirrors
@@ -1,0 +1,14 @@
+# metastat -p
+d40 -m d41 d42 1
+d41 1 1 c1t0d0s7
+d42 1 1 c1t1d0s7
+d20 -m d21 d22 1
+d21 1 1 c1t0d0s1
+d22 1 1 c1t1d0s1
+d10 -m d11 d12 1
+d11 1 1 c1t0d0s0
+d12 1 1 c1t1d0s0
+d30 -m d31 d32 1
+d31 1 1 c1t0d0s3
+d32 1 1 c1t1d0s3
+

--- a/t/data/metastat/metastat-snapshot-no-mirrors
+++ b/t/data/metastat/metastat-snapshot-no-mirrors
@@ -1,0 +1,3 @@
+$ metastat -p
+metastat: winn-syslogany-1: there are no existing databases
+

--- a/t/data/metastat/metastat-snapshot-with-soft-partition
+++ b/t/data/metastat/metastat-snapshot-with-soft-partition
@@ -1,0 +1,171 @@
+d50: Mirror
+    Submirror 0: d51
+      State: Okay         
+    Submirror 1: d52
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 16790400 blocks (8.0 GB)
+
+d51: Submirror of d50
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s5          0     No            Okay   Yes 
+
+
+d52: Submirror of d50
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s5          0     No            Okay   Yes 
+
+
+d40: Mirror
+    Submirror 0: d41
+      State: Okay         
+    Submirror 1: d42
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 16790400 blocks (8.0 GB)
+
+d41: Submirror of d40
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s4          0     No            Okay   Yes 
+
+
+d42: Submirror of d40
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s4          0     No            Okay   Yes 
+
+
+d30: Mirror
+    Submirror 0: d31
+      State: Okay         
+    Submirror 1: d32
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 16790400 blocks (8.0 GB)
+
+d31: Submirror of d30
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s3          0     No            Okay   Yes 
+
+
+d32: Submirror of d30
+    State: Okay         
+    Size: 16790400 blocks (8.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s3          0     No            Okay   Yes 
+
+
+d20: Mirror
+    Submirror 0: d21
+      State: Okay         
+    Submirror 1: d22
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 4212864 blocks (2.0 GB)
+
+d21: Submirror of d20
+    State: Okay         
+    Size: 4212864 blocks (2.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s1          0     No            Okay   Yes 
+
+
+d22: Submirror of d20
+    State: Okay         
+    Size: 4212864 blocks (2.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s1          0     No            Okay   Yes 
+
+
+d10: Mirror
+    Submirror 0: d11
+      State: Okay         
+    Submirror 1: d12
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 4212864 blocks (2.0 GB)
+
+d11: Submirror of d10
+    State: Okay         
+    Size: 4212864 blocks (2.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s0          0     No            Okay   Yes 
+
+
+d12: Submirror of d10
+    State: Okay         
+    Size: 4212864 blocks (2.0 GB)
+    Stripe 0:
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s0          0     No            Okay   Yes 
+
+
+d100: Soft Partition
+    Device: d60
+    State: Okay
+    Size: 377487360 blocks (180 GB)
+	Extent              Start Block              Block count
+	     0                       32                377487360
+
+d60: Mirror
+    Submirror 0: d61
+      State: Okay         
+    Submirror 1: d62
+      State: Okay         
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 455640576 blocks (217 GB)
+
+d61: Submirror of d60
+    State: Okay         
+    Size: 455640576 blocks (217 GB)
+    Stripe 0: (interlace: 32 blocks)
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t0d0s6          0     No            Okay   Yes 
+	c0t2d0s6      20352     No            Okay   Yes 
+
+
+d62: Submirror of d60
+    State: Okay         
+    Size: 455640576 blocks (217 GB)
+    Stripe 0: (interlace: 32 blocks)
+	Device     Start Block  Dbase        State Reloc Hot Spare
+	c0t1d0s6          0     No            Okay   Yes 
+	c0t3d0s6      20352     No            Okay   Yes 
+
+
+Device Relocation Information:
+Device   Reloc	Device ID
+c0t1d0   Yes  	id1,sd@SFUJITSU_MAW3147NCSUN146G000644C0A1FM____DAC0P6B0A1FM
+c0t3d0   Yes  	id1,sd@SFUJITSU_MAW3147NCSUN146G000644C0A2PA____DAC0P6B0A2PA
+c0t0d0   Yes  	id1,sd@SFUJITSU_MAW3147NCSUN146G000644C0A27F____DAC0P6B0A27F
+c0t2d0   Yes  	id1,sd@SFUJITSU_MAW3147NCSUN146G000644C0A1TJ____DAC0P6B0A1TJ

--- a/t/data/metastat/metastat.mirror
+++ b/t/data/metastat/metastat.mirror
@@ -1,0 +1,138 @@
+[09:06 AM] imap01-winn:/# metastat
+d30: Mirror
+    Submirror 0: d31
+      State: Okay
+    Submirror 1: d32
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 71083845 blocks (33 GB)
+
+d31: Submirror of d30
+    State: Okay
+    Size: 71083845 blocks (33 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t2d0s6          0     No            Okay   Yes
+
+
+d32: Submirror of d30
+    State: Okay
+    Size: 71083845 blocks (33 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t3d0s6          0     No            Okay   Yes
+
+
+d3: Mirror
+    Submirror 0: d8
+      State: Okay
+    Submirror 1: d9
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 12289806 blocks (5.9 GB)
+
+d8: Submirror of d3
+    State: Okay
+    Size: 12289806 blocks (5.9 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s7          0     No            Okay   Yes
+
+
+d9: Submirror of d3
+    State: Okay
+    Size: 12289806 blocks (5.9 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t1d0s7          0     No            Okay   Yes
+
+
+d1: Mirror
+    Submirror 0: d6
+      State: Okay
+    Submirror 1: d7
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 32769927 blocks (15 GB)
+
+d6: Submirror of d1
+    State: Okay
+    Size: 32769927 blocks (15 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s1          0     No            Okay   Yes
+
+
+d7: Submirror of d1
+    State: Okay
+    Size: 32769927 blocks (15 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t1d0s1          0     No            Okay   Yes
+
+
+d0: Mirror
+    Submirror 0: d4
+      State: Okay
+    Submirror 1: d5
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 16386408 blocks (7.8 GB)
+
+d4: Submirror of d0
+    State: Okay
+    Size: 16386408 blocks (7.8 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s0          0     No            Okay   Yes
+
+
+d5: Submirror of d0
+    State: Okay
+    Size: 16386408 blocks (7.8 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t1d0s0          0     No            Okay   Yes
+
+
+d2: Mirror
+    Submirror 0: d10
+      State: Okay
+    Submirror 1: d11
+      State: Okay
+    Pass: 1
+    Read option: roundrobin (default)
+    Write option: parallel (default)
+    Size: 9637704 blocks (4.6 GB)
+
+d10: Submirror of d2
+    State: Okay
+    Size: 9637704 blocks (4.6 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t0d0s3          0     No            Okay   Yes
+
+
+d11: Submirror of d2
+    State: Okay
+    Size: 9637704 blocks (4.6 GB)
+    Stripe 0:
+        Device     Start Block  Dbase        State Reloc Hot Spare
+        c1t1d0s3          0     No            Okay   Yes
+
+
+Device Relocation Information:
+Device   Reloc  Device ID
+c1t3d0   Yes    id1,sd@SFUJITSU_MAP3367N_SUN36G_00N0BF1K____
+c1t2d0   Yes    id1,sd@SSEAGATE_ST336607LSUN36G_3JA6LR7N00007422W6QK
+c1t1d0   Yes    id1,sd@SSEAGATE_ST336607LSUN36G_3JA69DGJ00007414CGBC
+c1t0d0   Yes    id1,sd@SSEAGATE_ST336607LSUN36G_3JA6AVF800007415Q53B
+

--- a/t/enabled.t
+++ b/t/enabled.t
@@ -17,6 +17,7 @@ my $commands = {
 	mdstat => ['<', TESTDIR . '/data/mdstat/mdstat-failed'],
 	dmraid => ['<', TESTDIR . '/data/dmraid/pr35'],
 	get_controller_no => ['<', TESTDIR . '/data/mpt/pr36/getctrlno1'],
+	snapshot => ['<', TESTDIR . '/data/metastat/metastat-snapshot-mirrors'],
 };
 
 my %params = (

--- a/t/enabled.t
+++ b/t/enabled.t
@@ -7,7 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 18;
+use Test::More tests => 19;
 use test;
 
 unshift(@utils::paths, TESTDIR . '/data/bin');

--- a/t/sudo.t
+++ b/t/sudo.t
@@ -7,7 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 18;
+use Test::More tests => 19;
 use test;
 
 my $bindir = TESTDIR . '/data/bin';
@@ -77,6 +77,9 @@ my %sudo = (
 	],
 	dmraid => [
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/dmraid -r",
+	],
+	metastat => [
+		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/metastat",
 	],
 );
 


### PR DESCRIPTION
This should fix issue #38 by providing test data for Solaris SVM (aka SDS/Disksuite) software raid via the metastat command.
The original code wasn't correctly matching State, so never returned any disks so this is now fixed and hot spare disks should be detected and generate warnings if not in an Available state.

Finally, I've added an active function so that the plugin will be disabled if SVM is not actively in use. Solaris generally comes with the metatstat too installed as default so this will ensure we don't just return Unknown if we fine the binary but no configuration