### PR TITLE
Arcconf

### DIFF
--- a/check_raid.pl
+++ b/check_raid.pl
@@ -2470,7 +2470,7 @@ sub program_names {
 sub commands {
 	{
 		'getstatus' => ['-|', '@CMD', 'GETSTATUS', '1'],
-		'getconfig' => ['-|', '@CMD', 'GETCONFIG', '$ctrl', 'AL', 'nologs'],
+		'getconfig' => ['-|', '@CMD', 'GETCONFIG', '$ctrl', 'AL'],
 	}
 }
 
@@ -2585,7 +2585,7 @@ sub parse_ctrl_config {
 	# Controller information, Logical/Physical device info
 	my (%c, @ld, $ld, @pd, $ch, $pd);
 
-	my $fh = $this->cmd('getconfig', { ctrl => $ctrl });
+	my $fh = $this->cmd('getconfig', { '$ctrl' => $ctrl });
 	my ($section, $subsection, $ok);
 	while (<$fh>) {
 		chomp;

--- a/check_raid.pl
+++ b/check_raid.pl
@@ -2894,8 +2894,10 @@ sub check_controller {
 	}
 
 	# Battery status
-	my @s = $this->battery_status($c);
-	push(@status, @s) if @s;
+        if ($this->bbu_monitoring) {
+		my @s = $this->battery_status($c);
+		push(@status, @s) if @s;
+	}
 
 	return @status;
 }


### PR DESCRIPTION
Hi,

there was a bug which lead to "arcconf CHECKCONFIG $ctrl" call instead of "arcconf CHECKCONFIG 1".
Also, the nolog flag does not exist in the 6.50 Version (which seems to be the most recent one).
The flag --bbu-monitoring was made optional for arcconf.

Gerhard

p.s. i see, the test is failing. That's in fact intended. because the faulty BBU is ignored now.