### PR TITLE
Honor --noraid option even when there are no active plugins

### DIFF
--- a/bin/check_raid.pl
+++ b/bin/check_raid.pl
@@ -133,7 +133,7 @@ $App::Monitoring::Plugin::CheckRaid::Utils::debug = $mp->opts->debug;
 
 my @plugins = $mc->active_plugins;
 if (!@plugins) {
-	$mp->plugin_exit(UNKNOWN, "No active plugins")
+	$mp->plugin_exit($plugin_options{options}{noraid_state}, "No active plugins (No RAID found)");
 }
 
 if ($mp->opts->sudoers) {


### PR DESCRIPTION
Currently, if there is no raid tool installed, and /proc/mdstat is in its default state (no raid there), UNKNOWN state is always returned.
This patch changes the behavior, it returns value defined in --noraid option, if present, or UNKNOWN, if absent.