### PR TITLE
Fix rpmbuild

### DIFF
--- a/nagios-plugin-check_raid.spec
+++ b/nagios-plugin-check_raid.spec
@@ -35,6 +35,7 @@ Suggests:	tw_cli-9xxx
 %endif
 BuildArch:	noarch
 BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
+AutoReqProv: no
 
 %description
 This plugin checks all RAID volumes (hardware and software) that can

--- a/nagios-plugin-check_raid.spec
+++ b/nagios-plugin-check_raid.spec
@@ -35,7 +35,7 @@ Suggests:	tw_cli-9xxx
 %endif
 BuildArch:	noarch
 BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
-AutoReqProv: no
+AutoReq: no
 
 %description
 This plugin checks all RAID volumes (hardware and software) that can


### PR DESCRIPTION
i build rpm with current spec 
and during installation i get 
```
error: Failed dependencies:
    perl(App::Monitoring::Plugin::CheckRaid) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::Plugin) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::Plugins::hpacucli) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::Plugins::lsscsi) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::SerialLine) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::Sudoers) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(App::Monitoring::Plugin::CheckRaid::Utils) is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(Module::Pluggable) >= 5.1 is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
	perl(Monitoring::Plugin) >= 0.37 is needed by nagios-plugin-check_raid-4.0.1-0.37.g516c63f.noarch
```
so installer analyzer thinks that modules that compiled to one file not installed and cancel installation 

as variant is to disable auto analyze requirements 
by adding `AutoReq: no` to spec file