### PR TITLE
Fix parsing arcconf physical devices with more than 2 subsections

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/arcconf.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/arcconf.pm
@@ -350,8 +350,14 @@ sub process_physical_device_information {
 	my (@pd, $cs, $s);
 	while (my($ch, $channel_data) = each %$data) {
 		while (my($pd, $d) = each %$channel_data) {
-			# FIXME: fallback to 'Device Phy Information' due parser bug
-			$cs = $d->{_} || $d->{'Device Phy Information'};
+			# Due to parser bugs not resetting the subsection, flatten all the 
+			# subsections into a single Hash
+			$cs = {};
+			foreach my $subsection (values %$d) {
+				foreach my $key (keys %$subsection) {
+					$cs->{$key} = $subsection->{$key};
+				}
+			}
 
 			# FIXME: this should be skipped in check process, not here
 			if ($pd eq '') {


### PR DESCRIPTION
A combination of arcconf 2.02 and an Adaptec 8805 produces a third
subsection under each physical device called 'Runtime Error Counters' which breaks the workaround
for the subsection hash key not being reset

Arcconf output attached, I'll also provide a patch sometime soon that takes into account the medium errors etc in this section for alerting as well

[arcconf.txt](https://github.com/glensc/nagios-plugin-check_raid/files/602700/arcconf.txt)
