### PR TITLE
removes duplicate parameter

### DIFF
--- a/bin/check_raid.pl
+++ b/bin/check_raid.pl
@@ -91,10 +91,6 @@ $mp->add_arg(
 	spec => 'bbu-monitoring',
 	help => 'Enable experimental monitoring of the BBU status',
 );
-$mp->add_arg(
-	spec => 'warnonly|W',
-	help => 'Treat CRITICAL errors as WARNING',
-);
 
 $mp->getopts;
 


### PR DESCRIPTION
Command-line parameter **warnonly|W** definition in lines [94-97](https://github.com/glensc/nagios-plugin-check_raid/blob/4.0.6/bin/check_raid.pl#L94-L97) was duplicating the definition in lines [42-45](https://github.com/glensc/nagios-plugin-check_raid/blob/4.0.6/bin/check_raid.pl#L42-L45). If script runs via ePN it failes due to the warning output - testable by running _perl -w_

```bash
# perl -w ./check_raid.pl
Duplicate specification "warnonly|W" for option "warnonly"
Duplicate specification "warnonly|W" for option "W"
Duplicate specification "warnonly|W" for option "warnonly"
Duplicate specification "warnonly|W" for option "W"
UNKNOWN: dm:[No devices to check]; mdstat:[md0(30.00 GiB raid1):UU, md2(100.00 GiB raid1):UU, md1(500.00 MiB raid1):UU]
```