### PR TITLE
dm: detect if raid devices present

### DIFF
--- a/bin/check_raid.pl
+++ b/bin/check_raid.pl
@@ -149,14 +149,14 @@ if ($mp->opts->debug) {
 	print "Visit <$BUGS_URL> how to report bugs\n\n",
 }
 
+if ($mp->opts->sudoers) {
+	sudoers($mp->opts->debug, $mc->active_plugins(1));
+	$mp->plugin_exit(OK, "sudoers updated");
+}
+
 my @plugins = $mc->active_plugins;
 if (!@plugins) {
 	$mp->plugin_exit($plugin_options{options}{noraid_status}, "No active plugins (No RAID found)");
-}
-
-if ($mp->opts->sudoers) {
-	sudoers($mp->opts->debug, @plugins);
-	$mp->plugin_exit(OK, "sudoers updated");
 }
 
 # print active plugins

--- a/bin/check_raid.pl
+++ b/bin/check_raid.pl
@@ -150,8 +150,8 @@ if ($mp->opts->debug) {
 }
 
 if ($mp->opts->sudoers) {
-	sudoers($mp->opts->debug, $mc->active_plugins(1));
-	$mp->plugin_exit(OK, "sudoers updated");
+	my $res = sudoers($mp->opts->debug, $mc->active_plugins(1));
+	$mp->plugin_exit(OK, $res ? "sudoers updated" : "sudoers not updated");
 }
 
 my @plugins = $mc->active_plugins;

--- a/lib/App/Monitoring/Plugin/CheckRaid.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid.pm
@@ -66,6 +66,8 @@ sub plugin {
 # Returns the plugin objects
 sub active_plugins {
 	my $this = shift;
+	# whether the query is for sudo rules
+	my $sudo = shift || 0;
 
 	my @plugins = ();
 
@@ -75,7 +77,7 @@ sub active_plugins {
 		next unless $plugin->can('check');
 
 		# skip inactive plugins (disabled or no tools available)
-		next unless $plugin->active;
+		next unless $plugin->active($sudo);
 
 		push(@plugins, $plugin);
 	}

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/dm.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/dm.pm
@@ -21,7 +21,7 @@ sub program_names {
 }
 
 sub active {
-	my ($this) = @_;
+	my ($this, $sudo) = @_;
 
 	# return if parent said NO
 	my $res = $this->SUPER::active(@_);

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/dm.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/dm.pm
@@ -20,6 +20,18 @@ sub program_names {
 	qw(dmsetup);
 }
 
+sub active {
+	my ($this) = @_;
+
+	# return if parent said NO
+	my $res = $this->SUPER::active(@_);
+	return $res unless $res;
+
+	# check if there really are any devices
+	my $c = $this->parse;
+	return !!@$c;
+}
+
 sub sudo {
 	my ($this, $deep) = @_;
 	# quick check when running check
@@ -54,7 +66,7 @@ sub parse_raid {
 		sync_ratio
 		sync_action
 		mismatch_cnt
-		);
+	);
 
 	my %h;
 	@h{@cols} = split;
@@ -127,6 +139,17 @@ sub get_fh {
 }
 
 sub parse {
+	my $this = shift;
+
+	# cache for single run
+	if (!defined($this->{parsed})) {
+		$this->{parsed} = $this->_parse;
+	}
+
+	return $this->{parsed};
+}
+
+sub _parse {
 	my $this = shift;
 
 	my @devices;

--- a/lib/App/Monitoring/Plugin/CheckRaid/Sudoers.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Sudoers.pm
@@ -13,6 +13,7 @@ our @EXPORT_OK = @EXPORT;
 #
 # if sudoers config has "#includedir" directive, add file to that dir
 # otherwise update main sudoers file
+# @returns true if file was updated
 sub sudoers {
 	my $dry_run = shift;
 	my @plugins = @_;
@@ -29,7 +30,7 @@ sub sudoers {
 
 	unless (@sudo) {
 		warn "Your configuration does not need to use sudo, sudoers not updated\n";
-		return;
+		return 0;
 	}
 
 	my @rules = join "\n", (
@@ -50,7 +51,7 @@ sub sudoers {
 		warn "--- sudoers ---\n";
 		print @rules;
 		warn "--- sudoers ---\n";
-		return;
+		return 0;
 	}
 
 	my $sudoers = find_file('/usr/local/etc/sudoers', '/etc/sudoers');
@@ -100,10 +101,12 @@ sub sudoers {
 		# use the new file
 		rename($new, $sudoers) or die $!;
 		warn "$sudoers file updated.\n";
-	} else {
-		warn "$sudoers file not changed.\n";
-		unlink($new);
+		return 1;
 	}
+
+	warn "$sudoers file not changed.\n";
+	unlink($new);
+	return 0;
 }
 
 # return first "#includedir" directive from $sudoers file

--- a/lib/App/Monitoring/Plugin/CheckRaid/Utils.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Utils.pm
@@ -51,6 +51,9 @@ sub find_sudo {
 	local $/ = undef;
 	local $_ = <$fh>;
 	close($fh) or die $!;
+	# prefer -n to skip password prompt
+	push(@sudo, '-n') if /-n/;
+	# ..if not supported, add -A as well
 	push(@sudo, '-A') if /-A/;
 
 	return \@sudo;


### PR DESCRIPTION
Fixes: #138, #158, #142, #170

----

Existing systems having dm active:
- sudo rules already existed, continues to run

Existing systems having dm inactive (no raids present):
- sudo rules still missing, plugin will not activate dm plugin