### PR TITLE
Enable checking of multiple mpt controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [4.0.9] - UNRELEASED
 
+- mpt-status: Enable checking of multiple mpt controllers, [#177]
+
+[#177]: https://github.com/glensc/nagios-plugin-check_raid/pull/177
 [4.0.9]: https://github.com/glensc/nagios-plugin-check_raid/compare/4.0.8...master
 
 ## [4.0.8] - 2017-09-01

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mpt.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mpt.pm
@@ -42,21 +42,24 @@ sub active {
 	return defined($id);
 }
 
-# get controller from mpt-status -p
-# FIXME: could there be multiple controllers?
 sub get_controller {
 	my $this = shift;
+	
+	# controller ID may be given on the command line
+	my $id = $this->{options}{'mpt-id'};
+	if (!$id) {
 
-	my $fh = $this->cmd('get_controller_no');
-	my $id;
-	while (<$fh>) {
-		chomp;
-		if (/^Found.*id=(\d{1,2}),.*/) {
-			$id = $1;
-			last;
+		# get controller from mpt-status -p
+		my $fh = $this->cmd('get_controller_no');
+		while (<$fh>) {
+			chomp;
+			if (/^Found.*id=(\d{1,2}),.*/) {
+				$id = $1;
+				last;
+			}
 		}
+		close $fh;
 	}
-	close $fh;
 
 	return $id;
 }

--- a/t/check_mpt.t
+++ b/t/check_mpt.t
@@ -47,6 +47,12 @@ my @tests = (
 		input => 'pr57/status13',
 		message => 'Volume 13 (RAID-1, 2 disks, 135 GiB): OPTIMAL',
 	},
+	{
+		status => OK,
+		get_controller_no => 'pr177/mpt-status-p',
+		input => 'pr177/mpt-status-i-2',
+		message => 'Volume 2 (RAID-1, 2 disks, 58 GiB): OPTIMAL',
+	},
 );
 
 # test that plugin can be created

--- a/t/check_mpt.t
+++ b/t/check_mpt.t
@@ -6,7 +6,8 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 31;
+use constant TESTS => 8;
+use Test::More tests => 1 + TESTS * 5;
 use test;
 
 my @tests = (

--- a/t/check_mpt.t
+++ b/t/check_mpt.t
@@ -53,6 +53,12 @@ my @tests = (
 		input => 'pr177/mpt-status-i-2',
 		message => 'Volume 2 (RAID-1, 2 disks, 58 GiB): OPTIMAL',
 	},
+	{
+		status => OK,
+		get_controller_no => 'pr177/mpt-status-p',
+		input => 'pr177/mpt-status-i-0',
+		message => 'Volume 0 (RAID-1, 2 disks, 33 GiB): OPTIMAL',
+	},
 );
 
 # test that plugin can be created

--- a/t/data/mpt/pr177/mpt-status-i-0
+++ b/t/data/mpt/pr177/mpt-status-i-0
@@ -1,0 +1,3 @@
+ioc0 vol_id 0 type IM, 2 phy, 33 GB, state OPTIMAL, flags ENABLED
+ioc0 phy 2 scsi_id 5 FUJITSU  MAY2036RCSUN36G  0401, 33 GB, state ONLINE, flags NONE
+ioc0 phy 3 scsi_id 1 FUJITSU  MAY2036RCSUN36G  0401, 33 GB, state ONLINE, flags NONE

--- a/t/data/mpt/pr177/mpt-status-i-2
+++ b/t/data/mpt/pr177/mpt-status-i-2
@@ -1,0 +1,3 @@
+ioc0 vol_id 2 type IM, 2 phy, 58 GB, state OPTIMAL, flags ENABLED
+ioc0 phy 1 scsi_id 4 ATA SSDSA2SH064G1GC 8860, 59 GB, state ONLINE, flags NONE
+ioc0 phy 0 scsi_id 3 ATA SSDSA2SH064G1GC 8860, 59 GB, state ONLINE, flags NONE

--- a/t/data/mpt/pr177/mpt-status-i-2
+++ b/t/data/mpt/pr177/mpt-status-i-2
@@ -1,3 +1,3 @@
 ioc0 vol_id 2 type IM, 2 phy, 58 GB, state OPTIMAL, flags ENABLED
-ioc0 phy 1 scsi_id 4 ATA SSDSA2SH064G1GC 8860, 59 GB, state ONLINE, flags NONE
-ioc0 phy 0 scsi_id 3 ATA SSDSA2SH064G1GC 8860, 59 GB, state ONLINE, flags NONE
+ioc0 phy 1 scsi_id 4 ATA      SSDSA2SH064G1GC  8860, 59 GB, state ONLINE, flags NONE
+ioc0 phy 0 scsi_id 3 ATA      SSDSA2SH064G1GC  8860, 59 GB, state ONLINE, flags NONE

--- a/t/data/mpt/pr177/mpt-status-p
+++ b/t/data/mpt/pr177/mpt-status-p
@@ -1,0 +1,2 @@
+Checking for SCSI ID:0
+Found SCSI id=0, use ''mpt-status -i 0`` to get more information.


### PR DESCRIPTION
Hi,

we have a few boxes with LSI controllers with two ids. mpt-status -p only shows the first ID:

root@osiris[~]# mpt-status -p
Checking for SCSI ID:0
Found SCSI id=0, use ''mpt-status -i 0`` to get more information.
root@osiris[~]# mpt-status -i 0
ioc0 vol_id 0 type IM, 2 phy, 33 GB, state OPTIMAL, flags ENABLED
ioc0 phy 2 scsi_id 5 FUJITSU  MAY2036RCSUN36G  0401, 33 GB, state ONLINE, flags NONE
ioc0 phy 3 scsi_id 1 FUJITSU  MAY2036RCSUN36G  0401, 33 GB, state ONLINE, flags NONE

But there is also ID 2:

root@osiris[~]# mpt-status -i 2
ioc0 vol_id 2 type IM, 2 phy, 58 GB, state OPTIMAL, flags ENABLED
ioc0 phy 1 scsi_id 4 ATA      SSDSA2SH064G1GC  8860, 59 GB, state ONLINE, flags NONE
ioc0 phy 0 scsi_id 3 ATA      SSDSA2SH064G1GC  8860, 59 GB, state ONLINE, flags NONE

I therefore added the possibility to give check_raid the controller id as an option, just as

root@osiris[nagios-plugin-check_raid]# ./check_raid.sh 
OK: mpt:[Volume 0 (RAID-1, 2 disks, 33 GiB): OPTIMAL]
root@osiris[nagios-plugin-check_raid]# ./check_raid.sh --plugin-option=mpt-id=2
OK: mpt:[Volume 2 (RAID-1, 2 disks, 58 GiB): OPTIMAL]

Thanks for the good work!