### PR TITLE
Add option to ignore failed fans

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/tw_cli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/tw_cli.pm
@@ -563,12 +563,15 @@ sub check {
 		# Something is wrong, but we are not sure what yet.
 		$this->warning unless $e->{status} eq 'OK';
 		my @estatus;
-		for my $fan_id (sort keys %{$e->{fans}}) {
-			my $f = $e->{fans}->{$fan_id};
-			my $s = $f->{status};
-			next if $s eq 'NOT-REPORTABLE' or $s eq 'NOT-INSTALLED' or $s eq 'NO-DEVICE';
-			$this->warning if $s ne 'OK';
-			push(@estatus, "$fan_id=$s($f->{rpm})");
+		
+		unless ($this->{options}{'ignore-fans'}) {
+			for my $fan_id (sort keys %{$e->{fans}}) {
+				my $f = $e->{fans}->{$fan_id};
+				my $s = $f->{status};
+				next if $s eq 'NOT-REPORTABLE' or $s eq 'NOT-INSTALLED' or $s eq 'NO-DEVICE';
+				$this->warning if $s ne 'OK';
+				push(@estatus, "$fan_id=$s($f->{rpm})");
+			}
 		}
 		for my $tmp_id (sort keys %{$e->{tempsensor}}) {
 			my $t = $e->{tempsensor}->{$tmp_id};

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/tw_cli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/tw_cli.pm
@@ -560,11 +560,12 @@ sub check {
 		# report.
 		next unless defined($e->{status});
 
-		# Something is wrong, but we are not sure what yet.
-		$this->warning unless $e->{status} eq 'OK';
 		my @estatus;
 		
 		unless ($this->{options}{'ignore-fans'}) {
+			# Something is wrong, but we are not sure what yet.
+			$this->warning unless $e->{status} eq 'OK';
+			
 			for my $fan_id (sort keys %{$e->{fans}}) {
 				my $f = $e->{fans}->{$fan_id};
 				my $s = $f->{status};


### PR DESCRIPTION
Hi,

I have a box with some fans in it which are connected to the mainboard instead of the enclosure. The mainboard reports all fans as working properly. tw-cli however reports the fans as failed (as they are not connected). I reported this to the manufacturer and they told me to simply ignore the fan warnings in tw-cli's output.

So this pull request adds a simple plugin option 'ignore-fans=1' which then disables checking of fans (and of the main enclosure status which goes to WARNING if anything seems b0rken).

Thanks,

Christopher
[tw-cli.txt](https://github.com/glensc/nagios-plugin-check_raid/files/1579478/tw-cli.txt)
