### PR TITLE
disable ePN

### DIFF
--- a/bin/check_raid.pl
+++ b/bin/check_raid.pl
@@ -6,6 +6,9 @@
 # See installation notes:
 # https://github.com/glensc/nagios-plugin-check_raid#installing
 #
+# nagios: -epn
+# https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/embeddedperl.html
+
 use Monitoring::Plugin 0.37;
 use App::Monitoring::Plugin::CheckRaid;
 use App::Monitoring::Plugin::CheckRaid::Sudoers;


### PR DESCRIPTION
not working under Embedded Perl Nagios: #179

the `-epn` line used to [exist in 3.x](https://github.com/glensc/nagios-plugin-check_raid/blob/3.2.5/check_raid.pl#L4) but got lost when switching to fatpacker and separate source packages.

docs:
- https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/embeddedperl.html
- https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/epnplugins.html

no actual documentation how to test and develop plugins ePN compatible, so not worth the effort.
  