### PR TITLE
enable usage of new HP ssacli (replacing hpssacli)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - mpt-status: Enable checking of multiple mpt controllers, [#177]
 - add [sensu] support, [#178]
+- enable usage of new HP ssacli (replacing hpssacli), [#182]
 
 [#177]: https://github.com/glensc/nagios-plugin-check_raid/pull/177
 [#178]: https://github.com/glensc/nagios-plugin-check_raid/issues/178
+[#182]: https://github.com/glensc/nagios-plugin-check_raid/pull/182
 [sensu]: https://sensuapp.org/docs/1.0/overview/what-is-sensu.html
 [4.0.9]: https://github.com/glensc/nagios-plugin-check_raid/compare/4.0.8...master
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Supported RAIDs that can be checked:
 - Adaptec AAC RAID via `aaccli` or `afacli` or `arcconf`
 - AIX software RAID via `lsvg`
 - HP/Compaq Smart Array via `cciss_vol_status` (hpsa supported too)
-- HP Smart Array Controllers and MSA Controllers via `hpacucli` and `hpssacli`
+- HP Smart Array Controllers and MSA Controllers with `hpacucli`, `hpssacli`, `ssacli`
 - HP Smart Array (MSA1500) via serial line
 - Linux 3ware SATA RAID via `tw_cli`
 - Linux Device Mapper RAID via dmraid

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
@@ -1,6 +1,6 @@
 package App::Monitoring::Plugin::CheckRaid::Plugins::hpacucli;
 
-## hpacucli/hpssacli support
+## hpacucli/hpssacli/ssacli support
 #
 # driver developers recommend to use cciss_vol_status for monitoring,
 # hpacucli/hpssacli shouldn't be used for monitoring due they obtaining global
@@ -172,7 +172,7 @@ sub scan_luns {
 			# "array A"
 			# "array A (Failed)"
 			# "array B (Failed)"
-			if (my($a, $s) = /^\s+array (\S+)(?:\s*\((\S+)\))?$/) {
+			if (my($a, $s) = /^\s+array (\S+)(?:\s*\((\S+)\))?$/i) {
 				$index++;
 				# Offset 0 is Array own status
 				# XXX: I don't like this one: undef could be false positive

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/ssacli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/ssacli.pm
@@ -1,0 +1,10 @@
+package App::Monitoring::Plugin::CheckRaid::Plugins::ssacli;
+
+# This plugin extends hpacucli plugin,
+# with the only difference that different program name will be used.
+
+use base 'App::Monitoring::Plugin::CheckRaid::Plugins::hpacucli';
+use strict;
+use warnings;
+
+1;

--- a/t/enabled.t
+++ b/t/enabled.t
@@ -7,7 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 28;
+use Test::More tests => 29;
 use test;
 
 unshift(@App::Monitoring::Plugin::CheckRaid::Utils::paths, TESTDIR . '/data/bin');

--- a/t/sudo.t
+++ b/t/sudo.t
@@ -80,6 +80,10 @@ my %sudo = (
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller all show status",
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller * logicaldrive all show",
 	],
+	ssacli => [
+		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller all show status",
+		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller * logicaldrive all show",
+	],
 	areca => [
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/cli64 rsf info",
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/cli64 disk info",

--- a/t/sudo.t
+++ b/t/sudo.t
@@ -7,7 +7,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 22;
+use Test::More tests => 23;
 use test;
 
 my $bindir = TESTDIR . '/data/bin';

--- a/t/sudo.t
+++ b/t/sudo.t
@@ -81,8 +81,8 @@ my %sudo = (
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller * logicaldrive all show",
 	],
 	ssacli => [
-		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller all show status",
-		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/hpssacli controller * logicaldrive all show",
+		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/ssacli controller all show status",
+		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/ssacli controller * logicaldrive all show",
 	],
 	areca => [
 		"CHECK_RAID ALL=(root) NOPASSWD: $bindir/cli64 rsf info",

--- a/t/test.pm
+++ b/t/test.pm
@@ -23,6 +23,7 @@ use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::gdth';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::hp_msa';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::hpacucli';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::hpssacli';
+use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::ssacli';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::ips';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::lsraid';
 use aliased 'App::Monitoring::Plugin::CheckRaid::Plugins::lsscsi';


### PR DESCRIPTION
Hi,

since version 10.60, released on December 19, the HP tools contain 'ssacli' instead of 'hpssascli'. Usage is the same, output only slightly different ('Array' instead of 'array'):

```
quincy# ssacli controller slot=0 logicaldrive all show 

Smart Array P420i in Slot 0 (Embedded)

   Array A

      logicaldrive 1 (223.5 GB, RAID 1, OK)


```

The patch adds a new plugin ssacli.pm which is basically the same as hpssacli.pm, so just a different name for hpacucli.pm. It also adds the switch for case-insensitive matching.

Thanks,

Christopher

[ssacli.txt](https://github.com/glensc/nagios-plugin-check_raid/files/1619118/ssacli.txt)
