### PR TITLE
mdstat: Check if a certain amount of spares are present

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mdstat.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mdstat.pm
@@ -163,8 +163,8 @@ sub check {
 
 	my @spare_options = ();
 
-	@spare_options = split(/\,/, $this->{options}{'mdstat_spare_count'})
-		if (exists $this->{options}{'mdstat_spare_count'});
+	@spare_options = split(/\,/, $this->{options}{mdstat_spare_count})
+		if (exists $this->{options}{mdstat_spare_count});
 
 	foreach (@md) {
 		my %md = %$_;
@@ -229,7 +229,7 @@ sub check {
 		push(@status, $s);
 	}
 
-	if ($#spare_options > 0)
+	if (scalar @spare_options > 0)
 	{
 		$this->critical;
 		foreach (@spare_options)

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mdstat.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/mdstat.pm
@@ -178,7 +178,7 @@ sub check {
 		if (exists $this->{options}{'mdstat_spare_count'})
 		{
 			my @spare_options = ();
-			@spare_options = split(/\|/, $this->{options}{'mdstat_spare_count'});
+			@spare_options = split(/\,/, $this->{options}{'mdstat_spare_count'});
 			foreach my $val (@spare_options)
 			{
 				my ($disk, $value) = split(/:/, $val);

--- a/t/data/mdstat/pr185_0
+++ b/t/data/mdstat/pr185_0
@@ -1,0 +1,6 @@
+Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10] 
+md1 : active raid5 sdh[3] sdg[2] sdj[6] sde[1] sdk[5](S) sdd[0]
+      3750244352 blocks super 1.2 level 5, 512k chunk, algorithm 2 [5/5] [UUUUU]
+      bitmap: 4/7 pages [16KB], 65536KB chunk
+
+unused devices: <none>

--- a/t/data/mdstat/pr185_1
+++ b/t/data/mdstat/pr185_1
@@ -1,0 +1,10 @@
+Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10] 
+md1 : active raid5 sdh[3] sdg[2] sdj[6] sde[1] sdk[5](S) sdd[0]
+      3750244352 blocks super 1.2 level 5, 512k chunk, algorithm 2 [5/5] [UUUUU]
+      bitmap: 4/7 pages [16KB], 65536KB chunk
+
+md2 : active raid5 sda[3] sdb[2] sdc[6] sdf[1] sdi[5](S) sdl[0](S) sdm[7]
+      3750244352 blocks super 1.2 level 5, 512k chunk, algorithm 2 [5/5] [UUUUU]
+      bitmap: 4/7 pages [16KB], 65536KB chunk
+
+unused devices: <none>


### PR DESCRIPTION
This pull request adds a plugin option to check if a certain amount of spares in an md array are present:

Example:
check_raid --plugin-option=mdstat_spare_count="md126:3,md127:2"

checks that md126 has at least 3 spares and that md127 has at least 2 spares
