### PR TITLE
Sort megacli devices numerically

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/megacli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/megacli.pm
@@ -291,7 +291,7 @@ sub check {
 	}
 
 	my %dstatus;
-	foreach my $dev (@{$c->{physical}}) {
+	foreach my $dev (sort {$a->{dev} <=> $b->{dev}} @{$c->{physical}}) {
 		if ($dev->{state} eq 'Online' || $dev->{state} eq 'Hotspare' || $dev->{state} eq 'Unconfigured(good)' || $dev->{state} eq 'JBOD') {
 			push(@{$dstatus{$dev->{state}}}, sprintf "%02d", $dev->{dev});
 

--- a/t/check_megacli.t
+++ b/t/check_megacli.t
@@ -36,7 +36,7 @@ my @tests = (
 		pdlist => 'issue41/pdlist',
 		ldinfo => 'issue41/ldinfo',
 		battery => 'empty',
-		message => 'Volumes(3): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal; Devices(6): 11,10,09,08,12,13=Online',
+		message => 'Volumes(3): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal; Devices(6): 08,09,10,11,12,13=Online',
 		perfdata => '',
 		longoutput => [],
 		c => 'issue41',
@@ -76,7 +76,7 @@ my @tests = (
 		pdlist => 'issue39/batteries.pdlist.1',
 		ldinfo => 'issue39/batteries.ldinfo.1',,
 		battery => 'issue39/batteries.bbustatus.1',
-		message => 'Volumes(1): DISK0.0:Optimal; Devices(2): 08,07=Online; Batteries(1): 0=Operational',
+		message => 'Volumes(1): DISK0.0:Optimal; Devices(2): 07,08=Online; Batteries(1): 0=Operational',
 		perfdata => 'Battery0_T=18;;;; Battery0_V=3923;;;;',
 		longoutput => [
 			"Battery0:",
@@ -162,7 +162,7 @@ my @tests = (
 		pdlist => 'issue45/MegaCli64-list.out',
 		ldinfo => 'issue45/MegaCli64-ldinfo.out',
 		battery => 'issue45/MegaCli64-adpbbucmd.out',
-		message => 'Volumes(7): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal,DISK3.3:Optimal,DISK4.4:Optimal,DISK5.5:Optimal,DISK6.6:Optimal; Devices(8): 11,12,13,14,10,15,09,08=Online; Batteries(1): 0=Optimal',
+		message => 'Volumes(7): DISK0.0:Optimal,DISK1.1:Optimal,DISK2.2:Optimal,DISK3.3:Optimal,DISK4.4:Optimal,DISK5.5:Optimal,DISK6.6:Optimal; Devices(8): 08,09,10,11,12,13,14,15=Online; Batteries(1): 0=Optimal',
 		perfdata => 'Battery0_T=34;;;; Battery0_V=4073;;;;',
 		longoutput => [
 			"Battery0:",
@@ -213,7 +213,7 @@ my @tests = (
 		pdlist => 'issue49/pdlist',
 		ldinfo => 'empty', # faked, as original is MISSING, see #49
 		battery => 'issue49/battery',
-		message => 'Volumes(0): ; Devices(6): 10,09,13,08,11=Online 14 (IBM-ESXSST9300603SS F B53B3SE0WJ1Y0825B53B)=Predictive; Batteries(1): 0=Faulty',
+		message => 'Volumes(0): ; Devices(6): 08,09,10,11,13=Online 14 (IBM-ESXSST9300603SS F B53B3SE0WJ1Y0825B53B)=Predictive; Batteries(1): 0=Faulty',
 		perfdata => 'Battery0_T=36;;;; Battery0_V=4049;;;;',
 		longoutput => [
 			"Battery0:",
@@ -304,7 +304,7 @@ my @tests = (
 		pdlist => 'issue123/pdlist',
 		ldinfo => 'issue123/ldinfo',
 		battery => 'empty',
-		message => 'Volumes(1): DISK0.0:Optimal,WriteCache:DISABLED; Devices(8): 11,10,08,12,13,14,16=Online 09 (IBM-ESXSM)=Predictive',
+		message => 'Volumes(1): DISK0.0:Optimal,WriteCache:DISABLED; Devices(8): 08,10,11,12,13,14,16=Online 09 (IBM-ESXSM)=Predictive',
 		perfdata => '',
 		longoutput => [],
 		c => 'issue123',


### PR DESCRIPTION
Hi,

one of our Supermicro servers has 36 local disks attached to a MegaRaid controller. megacli sorts the disks by enclosure id and slot number, but check_raid displays the device id instead. This may lead to unsorted output:

```
root@tc-covp[nagios-plugin-check_raid]# /usr/lib/nagios/plugins/check_raid 
CRITICAL: megacli:[Volumes(1): DISK0.0:Partially; Devices(35): 10,19,12,23,13,22,14,25,15,39,18,28,27,33,11,32,36,43,40,38,44,41,45,42,20,31,26,17,16,37,29,21,34,24,35=Online]

```
The attached patch sorts the devices numerically:

```
root@tc-covp[nagios-plugin-check_raid]# ./check_raid.sh 
CRITICAL: megacli:[Volumes(1): DISK0.0:Partially; Devices(35): 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45=Online]

```
Which makes it much easier to spot the missing disk id 30.

I tried to put the sort function into _join_status()_ first, but that did not work as not all controllers return disk names that are easily sortable (01 vs. 1:2 vs. Y2O483PAS).

Regards,

Christopher
