### PR TITLE
Fixing hpacucli to respect the cache_fail and bbulearn command options

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
@@ -286,11 +286,11 @@ sub cstatus {
 	# print those only if not ok and configured
 	if (($s = $c->{'Cache Status'}) && $s !~ /^(OK|Not Configured)/) {
 		push(@s, "Cache: $s");
-		$this->critical;
+		$this->cache_fail;
 	}
 	if (($s = $c->{'Battery/Capacitor Status'}) && $s !~ /^(OK|Not Configured)/) {
 		push(@s, "Battery: $s");
-		$this->critical;
+		$this->bbulearn;
 	}
 
 	# start with identifyier

--- a/t/check_hpacucli.t
+++ b/t/check_hpacucli.t
@@ -6,7 +6,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use constant TESTS => 15;
+use constant TESTS => 16;
 use Test::More tests => 1 + TESTS * 6;
 use test;
 
@@ -38,6 +38,17 @@ my @tests = (
 		logical => 'PR94/ld-show',
 		message => 'Smart Array P410i[OK]: Array A(OK)[LUN1:OK]',
 		c => '4',
+	},
+	{
+		status => OK,
+		controller => 'PR193/ctrl-status',
+		logical => 'PR193/ld-show',
+		message => 'Smart Array P420i[OK, Cache: Temporarily Disabled, Battery: Recharging]: Array A(OK)[LUN1:OK]',
+		c => 'PR193',
+		options => {
+			cache_fail_status => OK,
+			bbulearn_status => OK
+		},
 	},
 	{
 		status => CRITICAL,
@@ -138,6 +149,10 @@ foreach my $test (@tests) {
 		options => {
 		},
 	);
+
+	if ($test->{options}) {
+		$args{"options"} = $test->{options};
+	}
 
 	if ($test->{targets}) {
 		$args{'options'}{'hpacucli-target'} = $test->{targets};

--- a/t/data/hpacucli/PR193/ctrl-status
+++ b/t/data/hpacucli/PR193/ctrl-status
@@ -1,0 +1,6 @@
+Smart Array P420i in Slot 0 (Embedded)
+   Controller Status: OK
+   Cache Status: Temporarily Disabled
+   Battery/Capacitor Status: Recharging
+
+

--- a/t/data/hpacucli/PR193/ld-show
+++ b/t/data/hpacucli/PR193/ld-show
@@ -1,0 +1,6 @@
+Smart Array P420i in Slot 0 (Embedded)
+
+   array A
+
+      logicaldrive 1 (279.4 GB, RAID 1, OK)
+

--- a/t/dump/hpacucli/PR193
+++ b/t/dump/hpacucli/PR193
@@ -1,0 +1,27 @@
+$VAR1 = [
+          {
+            'Battery/Capacitor Status' => 'Recharging',
+            'Cache Status' => 'Temporarily Disabled',
+            'Controller Status' => 'OK',
+            'array' => [
+                         {
+                           'logicaldrives' => [
+                                                {
+                                                  'id' => '1',
+                                                  'raid' => 'RAID 1',
+                                                  'size' => '279.4 GB',
+                                                  'status' => 'OK'
+                                                }
+                                              ],
+                           'name' => 'A',
+                           'status' => 'OK'
+                         }
+                       ],
+            'controller' => 'Smart Array P420i',
+            'modes' => [
+                         'Embedded'
+                       ],
+            'slot' => '0',
+            'target' => 'slot=0'
+          }
+        ];


### PR DESCRIPTION
Hello,
A small fix to make the program respect the --cache-fail and --bbulearn settings.

Debug output:
```
# ./check_raid '-p' 'mdstat,megacli,mpt,megaraid,tw_cli,cciss,sas2ircu,smartctl,hpssacli' '--cache-fail' 'OK' --bbulearn OK -d
check_raid 4.0.9
Visit <https://github.com/glensc/nagios-plugin-check_raid#reporting-bugs> how to report bugs
Please include output of **ALL** commands in bugreport
                             
DEBUG EXEC: /proc/mdstat at ./check_raid line 503.
DEBUG EXEC: /usr/sbin/hpssacli controller all show status at ./check_raid line 503.
DEBUG EXEC: /usr/sbin/hpssacli controller slot=0 logicaldrive all show at ./check_raid line 503.
OK: hpssacli:[Smart Array P420i[OK, Cache: Temporarily Disabled, Battery: Recharging]: Array A(OK)[LUN1:OK]]
```

```
# cat /proc/mdstat
Personalities : 
unused devices: <none>
```

```
# /usr/sbin/hpssacli controller all show status

Smart Array P420i in Slot 0 (Embedded)
   Controller Status: OK
   Cache Status: Temporarily Disabled
   Battery/Capacitor Status: Recharging



```
```
# /usr/sbin/hpssacli controller slot=0 logicaldrive all show

Smart Array P420i in Slot 0 (Embedded)

   array A

      logicaldrive 1 (279.4 GB, RAID 1, OK)


```