### PR TITLE
Fixes for cciss_vol_status 1.12a

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
@@ -263,10 +263,11 @@ sub parse {
 		# /dev/cciss/c0d0: (Smart Array P400i) RAID 1 Volume 0 status: OK
 		# /dev/sda: (Smart Array P410i) RAID 1 Volume 0 status: OK.
 		# /dev/sda: (Smart Array P410i) RAID 5 Volume 0 status: OK.   At least one spare drive designated.  At least one spare drive has failed.
+		# /dev/sda: (Smart Array P420i) RAID 1(1+0) Volume 0 status: OK.
 		if (my($file, $board_name, $raid_level, $volume_number, $certain, $status, $spare_drive_status) = m{
 			^(/dev/[^:]+):\s        # File
 			\(([^)]+)\)\s           # Board Name
-			(RAID\s\d+|\([^)]+\))\s # RAID level
+			(RAID\s\d+(?:\(\d\+\d\))?|\([^)]+\))\s # RAID level with optional '(X+Y)')
 			Volume\s(\d+)           # Volume number
 			(\(\?\))?\s             # certain?
 			status:\s(.*?)\.        # status (without a dot)

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
@@ -300,7 +300,7 @@ sub parse {
 		if (my ($phys1, $phys2, $box, $bay, $model, $serial_no, $fw_rev, $status) = m{
 			\sconnector\s(.)(.)\s # Phys connector 1&2
 			box\s(\d+)\s          # phys_box_on_bus
-			bay\s(\d+)\s          # phys_bay_in_box
+			bay\s(\d+)\s{1,2}     # phys_bay_in_box
 			(.{40})\s             # model
 			(.{40})\s             # serial no
 			(.{8})\s              # fw rev

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
@@ -341,6 +341,8 @@ sub parse {
 			my $cache = $c{$cdev}{cache};
 			my %map = (
 				configured => qr/Cache configured: (.+)/,
+				total_cache_memory => qr/Total cache memory: (.+)/,
+				cache_ratio => qr/Cache Ratio: (.+)/,
 				read_cache_memory => qr/Read cache memory: (.+)/,
 				write_cache_memory => qr/Write cache memory: (.+)/,
 				write_cache_enabled => qr/Write cache enabled: (.+)/,
@@ -465,6 +467,8 @@ sub check {
 			}
 
 			push(@cstatus, "FlashCache") if $cache->{flash_cache};
+			push(@cstatus, "TotalMem:$cache->{total_cache_memory}") if $cache->{total_cache_memory};
+			push(@cstatus, "Ratio:'$cache->{cache_ratio}'") if $cache->{cache_ratio};
 			push(@cstatus, "ReadMem:$cache->{read_cache_memory}") if $cache->{read_cache_memory};
 			push(@cstatus, "WriteMem:$cache->{write_cache_memory}") if $cache->{write_cache_memory};
 

--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/cciss.pm
@@ -172,7 +172,7 @@ sub cciss_vol_status_version {
 		close $fh;
 		return 0 unless $line;
 
-		if (my($v) = $line =~ /^cciss_vol_status version ([\d.]+)$/) {
+		if (my($v) = $line =~ /^cciss_vol_status version ([\d.]+)[a-z]?$/) {
 			return 0 + $v;
 		}
 		return 0;

--- a/t/check_cciss.t
+++ b/t/check_cciss.t
@@ -6,7 +6,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use constant TESTS => 13;
+use constant TESTS => 14;
 use Test::More tests =>  1 + TESTS * 6;
 use test;
 
@@ -166,6 +166,18 @@ my @tests = (
 		smartctl => '',
 		message => '/dev/sda(Smart Array): Volume 0 (RAID 5): OK, Drives(4): 1I-1-1,1I-1-2,1I-1-3,1I-1-4=OK, Cache: WriteCache FlashCache ReadMem:182 MiB WriteMem:1634 MiB',
 		c => 'issue149',
+	},
+	{
+		status => OK,
+		lsscsi => 'cciss/issue205/lsscsi-g',
+		detect_hpsa => '',
+		detect_cciss => '',
+		version => 'cciss-1.12a',
+		controller => 'issue205/cciss_vol_status-V_dev_sg0',
+		cciss_proc => '',
+		smartctl => '',
+		message => '/dev/sda(Smart Array P420i): Volume 0 (RAID 1(1+0)): OK, Drives(8): 1I-1-1,1I-1-2,1I-1-3,1I-1-4,2I-1-5,2I-1-6,2I-1-7,2I-1-8=OK, Cache: WriteCache FlashCache TotalMem:816 MiB Ratio:\'10% Read / 90% Write\' ReadMem:81 MiB WriteMem:735 MiB',
+		c => 'issue205',
 	},
 );
 

--- a/t/data/cciss/cciss-1.12a
+++ b/t/data/cciss/cciss-1.12a
@@ -1,0 +1,1 @@
+cciss_vol_status version 1.12a

--- a/t/data/cciss/issue205/cciss_vol_status-V_dev_sg0
+++ b/t/data/cciss/issue205/cciss_vol_status-V_dev_sg0
@@ -1,0 +1,23 @@
+Controller: Smart Array P420i
+  Board ID: 0x3354103c
+  Logical drives: 1
+  Running firmware: 8.32
+  ROM firmware: 8.32
+/dev/sda: (Smart Array P420i) RAID 1(1+0) Volume 0 status: OK. 
+  Physical drives: 8
+         connector 1I box 1 bay 1                  HP      EG0900FCVBL                          S0N2BEHX0000K50648RD     HPD9 OK
+         connector 1I box 1 bay 2                  HP      EG0900FCVBL                          S0N2C5810000K50663MY     HPD9 OK
+         connector 1I box 1 bay 3                  HP      EG0900FCSPN                              3410A0IPFTM11409     HPD0 OK
+         connector 1I box 1 bay 4                  HP      EG0900FCVBL                          S0N18Z0Q0000B429BNNF     HPD9 OK
+         connector 2I box 1 bay 5                  HP      EG0900FCSPN                              24R0A0AGFTM11409     HPD0 OK
+         connector 2I box 1 bay 6                  HP      EG0900FBVFQ                                      KVK7YKBJ     HPDE OK
+         connector 2I box 1 bay 7                  HP      EG0900FCVBL                          S0N25NCW0000M501EUAH     HPD9 OK
+         connector 2I box 1 bay 8                  HP      EG0900FCSPN                              93K0A0HFFTM11338     HPD0 OK
+/dev/sg0(Smart Array P420i:0): Non-Volatile Cache status:
+                   Cache configured: Yes
+                 Total cache memory: 816 MiB
+                        Cache Ratio: 10% Read / 90% Write
+                  Read cache memory: 81 MiB
+                 Write cache memory: 735 MiB
+                Write cache enabled: Yes
+   Flash backed cache present

--- a/t/data/cciss/issue205/lsscsi-g
+++ b/t/data/cciss/issue205/lsscsi-g
@@ -1,0 +1,2 @@
+[0:0:0:0]    storage HP       P420i            8.32  -          /dev/sg0 
+[0:1:0:0]    disk    HP       LOGICAL VOLUME   8.32  /dev/sda   /dev/sg1 

--- a/t/dump/cciss/issue205
+++ b/t/dump/cciss/issue205
@@ -1,0 +1,118 @@
+$VAR1 = {
+          '/dev/sda' => {
+                          'board_name' => 'Smart Array P420i',
+                          'cache' => {
+                                       'board' => 'Smart Array P420i',
+                                       'cache_ratio' => '10% Read / 90% Write',
+                                       'configured' => 'Yes',
+                                       'file' => '/dev/sg0',
+                                       'flash_cache' => 1,
+                                       'instance' => 0,
+                                       'read_cache_memory' => '81 MiB',
+                                       'total_cache_memory' => '816 MiB',
+                                       'write_cache_enabled' => 'Yes',
+                                       'write_cache_memory' => '735 MiB'
+                                     },
+                          'drives' => {
+                                        '1I-1-1' => {
+                                                      'bay' => 1,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD9',
+                                                      'model' => 'HP      EG0900FCVBL',
+                                                      'phys1' => '1',
+                                                      'phys2' => 'I',
+                                                      'serial' => 'S0N2BEHX0000K50648RD',
+                                                      'slot' => '1I-1-1',
+                                                      'status' => 'OK'
+                                                    },
+                                        '1I-1-2' => {
+                                                      'bay' => 2,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD9',
+                                                      'model' => 'HP      EG0900FCVBL',
+                                                      'phys1' => '1',
+                                                      'phys2' => 'I',
+                                                      'serial' => 'S0N2C5810000K50663MY',
+                                                      'slot' => '1I-1-2',
+                                                      'status' => 'OK'
+                                                    },
+                                        '1I-1-3' => {
+                                                      'bay' => 3,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD0',
+                                                      'model' => 'HP      EG0900FCSPN',
+                                                      'phys1' => '1',
+                                                      'phys2' => 'I',
+                                                      'serial' => '3410A0IPFTM11409',
+                                                      'slot' => '1I-1-3',
+                                                      'status' => 'OK'
+                                                    },
+                                        '1I-1-4' => {
+                                                      'bay' => 4,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD9',
+                                                      'model' => 'HP      EG0900FCVBL',
+                                                      'phys1' => '1',
+                                                      'phys2' => 'I',
+                                                      'serial' => 'S0N18Z0Q0000B429BNNF',
+                                                      'slot' => '1I-1-4',
+                                                      'status' => 'OK'
+                                                    },
+                                        '2I-1-5' => {
+                                                      'bay' => 5,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD0',
+                                                      'model' => 'HP      EG0900FCSPN',
+                                                      'phys1' => '2',
+                                                      'phys2' => 'I',
+                                                      'serial' => '24R0A0AGFTM11409',
+                                                      'slot' => '2I-1-5',
+                                                      'status' => 'OK'
+                                                    },
+                                        '2I-1-6' => {
+                                                      'bay' => 6,
+                                                      'box' => 1,
+                                                      'fw' => 'HPDE',
+                                                      'model' => 'HP      EG0900FBVFQ',
+                                                      'phys1' => '2',
+                                                      'phys2' => 'I',
+                                                      'serial' => 'KVK7YKBJ',
+                                                      'slot' => '2I-1-6',
+                                                      'status' => 'OK'
+                                                    },
+                                        '2I-1-7' => {
+                                                      'bay' => 7,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD9',
+                                                      'model' => 'HP      EG0900FCVBL',
+                                                      'phys1' => '2',
+                                                      'phys2' => 'I',
+                                                      'serial' => 'S0N25NCW0000M501EUAH',
+                                                      'slot' => '2I-1-7',
+                                                      'status' => 'OK'
+                                                    },
+                                        '2I-1-8' => {
+                                                      'bay' => 8,
+                                                      'box' => 1,
+                                                      'fw' => 'HPD0',
+                                                      'model' => 'HP      EG0900FCSPN',
+                                                      'phys1' => '2',
+                                                      'phys2' => 'I',
+                                                      'serial' => '93K0A0HFFTM11338',
+                                                      'slot' => '2I-1-8',
+                                                      'status' => 'OK'
+                                                    }
+                                      },
+                          'pd count' => '8',
+                          'volumes' => {
+                                         '0' => {
+                                                  'board_name' => 'Smart Array P420i',
+                                                  'certain' => 1,
+                                                  'raid_level' => 'RAID 1(1+0)',
+                                                  'spare_drive_status' => '',
+                                                  'status' => 'OK',
+                                                  'volume_number' => '0'
+                                                }
+                                       }
+                        }
+        };


### PR DESCRIPTION
Hi, I have some fixes for check_raid to be able to cope with the changed text output of cciss_vol_status version 1.12a.

First opening the WIP MR with the code changes, so that I have a number to use while trying to get additional test cases set up.