### PR TITLE
hpacucli plugin fix case with missing controllers

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/hpacucli.pm
@@ -130,6 +130,13 @@ sub scan_targets {
 			next;
 		}
 
+		# Case for installed hpacucli but missing controllers
+		if (
+			/No controllers detected/
+		) {
+			return;
+		}
+
 		# Other statuses, try "key: value" pairs
 		if (my ($key, $value) = /^\s*(.+?):\s+(.+?)$/) {
 			$targets{$target}{$key} = $value;


### PR DESCRIPTION
Currently (check_raid version 4.0.10) in hpacucli plugin, checking of missing controllers is done incorrectly.

In my server if I install hpacucli at any server without a controller (non-hp server is also ok), I get that plugin erroring in output:
```
UNKNOWN: hpacucli:[[ERROR, The controller must be identified by slot, chassisname, wwn,, Battery: missing]]:
```

After my change it will be:
```
WARNING: hpacucli:[No Controllers were found on this machine]:
```

The text for no controllers was already there, but it did not applied, because scan_targets function returned something (instead of returning null) and scan_luns was next invoked, which will not happen in correct case.

Sorry, I could not run tests successfully, because perl complained it misses aliased.pm even when I used PERL_USE_UNSAFE_INC=1.

I will write the output of hpacucli here for the commands runned by plugin:

The first command
```
root@server# hpacucli controller all show status

Error: No controllers detected.

root@server#
```

The second command
```
root@server# hpacucli controller * logicaldrive all show

Error: The controller must be identified by slot, chassisname, wwn,
       serialnumber, or IPF information.

root@server#
```

Version of hpacucli
```
root@server# hpacucli version

   ACU CLI Version: 9.20.9.0
   SoulAPI Version: 6.1.11.0

root@server#
```

Debug output (after fixing):
```
# perl ./check_raid.pl -d
check_raid 4.0.10
Visit <https://github.com/glensc/nagios-plugin-check_raid#reporting-bugs> how to report bugs
Please include output of **ALL** commands in bugreport

DEBUG EXEC: /sbin/dmsetup status --noflush at ./check_raid.pl line 503.
DEBUG EXEC: /proc/mdstat at ./check_raid.pl line 503.
DEBUG EXEC: /usr/sbin/hpacucli controller all show status at ./check_raid.pl line 503.
DEBUG EXEC: /proc/mdstat at ./check_raid.pl line 503.
WARNING: hpacucli:[No Controllers were found on this machine]; mdstat:[md127(167.05 GiB raid1):UU]
```

Debug output (before fixing):
```
# perl ./check_raid.pl -d
check_raid 4.0.10
Visit <https://github.com/glensc/nagios-plugin-check_raid#reporting-bugs> how to report bugs
Please include output of **ALL** commands in bugreport

DEBUG EXEC: /sbin/dmsetup status --noflush at ./check_raid.pl line 503.
DEBUG EXEC: /proc/mdstat at ./check_raid.pl line 503.
DEBUG EXEC: /usr/sbin/hpacucli controller all show status at ./check_raid.pl line 503.
Use of uninitialized value $target in hash element at ./check_raid.pl line 3012, <$fh> line 2.
Use of uninitialized value in substitution iterator at ./check_raid.pl line 484.
DEBUG EXEC: /usr/sbin/hpacucli controller  logicaldrive all show at ./check_raid.pl line 503.
Use of uninitialized value in quotemeta at ./check_raid.pl line 3078, <$fh> line 3.
Use of uninitialized value in string ne at ./check_raid.pl line 3149.
Use of uninitialized value $name in concatenation (.) or string at ./check_raid.pl line 3176.
DEBUG EXEC: /proc/mdstat at ./check_raid.pl line 503.
UNKNOWN: hpacucli:[[ERROR, The controller must be identified by slot, chassisname, wwn,]]; mdstat:[md127(167.05 GiB raid1):UU]
```