### PR TITLE
Make use of GitHub Actions

### DIFF
--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -1,0 +1,38 @@
+name: Test suite
+
+on: [push]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - '5.36'
+          - '5.34'
+          - '5.32'
+          - '5.30'
+          - '5.28'
+          - '5.26'
+          - '5.24'
+          - '5.22'
+          - '5.20'
+          - '5.18'
+          - '5.16'
+          - '5.14'
+          - '5.12'
+          - '5.10'
+          - '5.8'
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@main
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - run: perl -V
+      - run: cpanm --notest --installdeps --verbose .
+      - run: perl -c -Ilib bin/check_raid.pl
+      - run: make test

--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires 'Monitoring::Plugin' => '0.37';
 
 on 'test' => sub {
 	requires 'ExtUtils::MakeMaker::CPANfile';
+	requires 'aliased';
 };
 
 # don't want these to be installed to 'local'

--- a/t/check_hp_msa.t
+++ b/t/check_hp_msa.t
@@ -3,9 +3,9 @@ BEGIN {
 	(my $srcdir = $0) =~ s,/[^/]+$,/,;
 	unshift @INC, $srcdir;
 
-	if ($ENV{TRAVIS}) {
+	if ($ENV{TRAVIS} || $ENV{CI}) {
 		use Test::More;
-		plan skip_all => "Skipping test as can't open /dev in travis";
+		plan skip_all => "Skipping test as can't open /dev in travis or CI pipelines";
 		exit 0;
 	}
 }

--- a/t/check_hpacucli.t
+++ b/t/check_hpacucli.t
@@ -6,7 +6,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use constant TESTS => 16;
+use constant TESTS => 17;
 use Test::More tests => 1 + TESTS * 6;
 use test;
 

--- a/t/dump/hpacucli/pr207
+++ b/t/dump/hpacucli/pr207
@@ -1,0 +1,1 @@
+$VAR1 = undef;


### PR DESCRIPTION
This adds support for GitHub Actions (comparable to Travis, but directly included in GitHub so that one can easily see whether the tests are passing).

This PR also fixes some failing tests.

Examples: https://github.com/csware/nagios-plugin-check_raid/actions and https://github.com/csware/nagios-plugin-check_raid/actions/runs/3862443935