### PR TITLE
add "Raid Set" status on areca that allow a disk in a raid to be OK

### DIFF
--- a/lib/App/Monitoring/Plugin/CheckRaid/Plugins/areca.pm
+++ b/lib/App/Monitoring/Plugin/CheckRaid/Plugins/areca.pm
@@ -135,6 +135,9 @@ sub check {
 		} elsif ($usage =~ /Pass Through/) {
 			# Pass Through is OK
 			push(@{$drivestatus{$array_name}}, $id);
+		} elsif ($usage =~ /Raid Set/) {
+			# Disk in a raid is OK
+			push(@{$drivestatus{$array_name}}, $id);
 		} else {
 			push(@{$drivestatus{$array_name}}, $id);
 			$this->critical;


### PR DESCRIPTION
On latest CLI tool from areca, I get a critical response whit two disk in a Raid :+1: 

```
  # Enc# Slot#   ModelName                        Capacity  Usage
===============================================================================
  1  01  Slot#1  SEAGATE ST1000NM0023             1000.2GB  Raid Set # 000  
  2  01  Slot#2  SEAGATE ST1000NM0023             1000.2GB  Raid Set # 000  
  3  01  Slot#3  N.A.                                0.0GB  N.A.      
  4  01  Slot#4  N.A.                                0.0GB  N.A.      
  5  01  Slot#5  N.A.                                0.0GB  N.A.      
  6  01  Slot#6  N.A.                                0.0GB  N.A.      
  7  01  Slot#7  N.A.                                0.0GB  N.A.      
  8  01  Slot#8  N.A.                                0.0GB  N.A.      
===============================================================================
GuiErrMsg<0x00>: Success.
```

My patch force to check if 'Raid Set' is present and declare OK.