### PR TITLE
Test data for lsraid

### DIFF
--- a/t/data/lsraid/centos2_good.txt
+++ b/t/data/lsraid/centos2_good.txt
@@ -1,0 +1,10 @@
+[dev   9,   0] /dev/md0         220071C8.96E87A52.5AA5BD5B.EB5F08FF online
+[dev   3,   1] /dev/hda1        220071C8.96E87A52.5AA5BD5B.EB5F08FF good
+[dev   3,  65] /dev/hdb1        220071C8.96E87A52.5AA5BD5B.EB5F08FF good
+[dev  22,   1] /dev/hdc1        220071C8.96E87A52.5AA5BD5B.EB5F08FF spare
+
+[dev   9,   1] /dev/md1         15C99EAE.88A2CDC2.519B5534.B69E747E online
+[dev   3,   2] /dev/hda2        15C99EAE.88A2CDC2.519B5534.B69E747E good
+[dev   3,  66] /dev/hdb2        15C99EAE.88A2CDC2.519B5534.B69E747E good
+[dev  22,   2] /dev/hdc2        15C99EAE.88A2CDC2.519B5534.B69E747E spare
+

--- a/t/data/lsraid/centos2_sync.txt
+++ b/t/data/lsraid/centos2_sync.txt
@@ -1,0 +1,9 @@
+[dev   9,   0] /dev/md0         220071C8.96E87A52.5AA5BD5B.EB5F08FF online
+[dev   3,   1] /dev/hda1        220071C8.96E87A52.5AA5BD5B.EB5F08FF good
+[dev  22,   1] /dev/hdc1        220071C8.96E87A52.5AA5BD5B.EB5F08FF good
+
+[dev   9,   1] /dev/md1         15C99EAE.88A2CDC2.519B5534.B69E747E online
+[dev   3,   2] /dev/hda2        15C99EAE.88A2CDC2.519B5534.B69E747E good
+[dev   ?,   ?] (unknown)        00000000.00000000.00000000.00000000 missing
+[dev  22,   2] /dev/hdc2        15C99EAE.88A2CDC2.519B5534.B69E747E spare
+

--- a/t/data/lsraid/centos3_failed.txt
+++ b/t/data/lsraid/centos3_failed.txt
@@ -1,0 +1,15 @@
+[dev   9,   0] /dev/md0         656728BD.8EB5EAFC.DE434304.C7077AA1 online
+[dev   3,   1] /dev/hda1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev   3,  65] /dev/hdb1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev  22,   1] /dev/hdc1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+
+[dev   9,   1] /dev/md1         35BF91DC.7B66416F.85A926FB.69511BF5 online
+[dev   3,   2] /dev/hda2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev   3,  66] /dev/hdb2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev  22,   2] /dev/hdc2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+
+[dev   9,   2] /dev/md2         FB49011A.1964BBB7.F3E4906F.AEFE6E08 online
+[dev   3,   3] /dev/hda3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 good
+[dev   3,  67] /dev/hdb3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 good
+[dev  22,   3] /dev/hdc3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 failed
+

--- a/t/data/lsraid/centos3_stopped.txt
+++ b/t/data/lsraid/centos3_stopped.txt
@@ -1,0 +1,15 @@
+[dev   9,   0] /dev/md0         656728BD.8EB5EAFC.DE434304.C7077AA1 online
+[dev   3,   1] /dev/hda1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev   3,  65] /dev/hdb1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev  22,   1] /dev/hdc1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+
+[dev   9,   1] /dev/md1         35BF91DC.7B66416F.85A926FB.69511BF5 online
+[dev   3,   2] /dev/hda2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev   3,  66] /dev/hdb2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev  22,   2] /dev/hdc2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+
+[dev   9,   2] /dev/md2         FB49011A.1964BBB7.F3E4906F.AEFE6E08 offline
+[dev   3,   3] /dev/hda3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 good
+[dev   3,  67] /dev/hdb3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 failed
+[dev  22,   3] /dev/hdc3        FB49011A.1964BBB7.F3E4906F.AEFE6E08 failed
+

--- a/t/data/lsraid/centos3_sync.txt
+++ b/t/data/lsraid/centos3_sync.txt
@@ -1,0 +1,16 @@
+[dev   9,   0] /dev/md0         656728BD.8EB5EAFC.DE434304.C7077AA1 online
+[dev   3,   1] /dev/hda1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev   3,  65] /dev/hdb1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+[dev  22,   1] /dev/hdc1        656728BD.8EB5EAFC.DE434304.C7077AA1 good
+
+[dev   9,   1] /dev/md1         35BF91DC.7B66416F.85A926FB.69511BF5 online
+[dev   3,   2] /dev/hda2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev   3,  66] /dev/hdb2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+[dev  22,   2] /dev/hdc2        35BF91DC.7B66416F.85A926FB.69511BF5 good
+
+[dev   9,   2] /dev/md2         0A62F51B.555955BE.E618D214.DFB7F24B online
+[dev   3,   3] /dev/hda3        0A62F51B.555955BE.E618D214.DFB7F24B good
+[dev   3,  67] /dev/hdb3        0A62F51B.555955BE.E618D214.DFB7F24B good
+[dev   ?,   ?] (unknown)        00000000.00000000.00000000.00000000 missing
+[dev  22,   3] /dev/hdc3        0A62F51B.555955BE.E618D214.DFB7F24B spare
+


### PR DESCRIPTION
The `lsraid` plugin is marked broken because of missing test data (https://github.com/glensc/nagios-plugin-check_raid/blob/master@%7B2023-10-19T15:05:44Z%7D/lib/App/Monitoring/Plugin/CheckRaid/Plugins/lsraid.pm#L4).

This commit adds `lsraid` output for centos2 and centos3 hosts fixing that part.

However, the plugin is seemingly broken because it expects a single space instead of multiple spaces inside the regex when parsing disk or array status. It also will ignore missing disks as they do not match the regex...

Maybe just get rid of the `lsraid` plugin completely? I doubt anyone is still using it...